### PR TITLE
Fix ダイアログをクローズしたときにコンテンツをnullに

### DIFF
--- a/src/components/def-dialog-detail.vue
+++ b/src/components/def-dialog-detail.vue
@@ -200,6 +200,9 @@ export default class Index extends Vue {
 
   chDetail(): void {
     this.$store.commit('visible/chDetail', { display: false });
+    this.localMemo = '';
+    this.$store.commit('table/setUserData', { userData: null });
+    this.$store.commit('table/setLooking', { period: null });
   }
 
   async save() {

--- a/src/store/table/type.ts
+++ b/src/store/table/type.ts
@@ -66,8 +66,8 @@ export interface M {
   /**
    * 直前にクリックした授業の内容を更新
    */
-  setLooking: { period: Period };
-  setUserData: { userData: UserLectureEntity };
+  setLooking: { period: Period | null };
+  setUserData: { userData: UserLectureEntity | null };
 }
 export interface RM {
   'table/setModule': M['setModule'];


### PR DESCRIPTION
## 概要/目的

#71 とりあえずの解決策

## やったこと・変更内容

closeしたときに前のデータを消去すればちらつきがなくなる。

## 確認したこと

- [x] 授業を選択してその後に他のを選択

## 備考

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
