### PR TITLE
Android版ボタンのウェブ臭さを消した

### DIFF
--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -14,7 +14,6 @@ body {
     border: none;
     background: none;
     transition: transform 0.3s liner;
-    cursor: pointer;
     &:focus {
         outline: 2px dashed #17171d;
     }

--- a/src/components/def-dialog-add.vue
+++ b/src/components/def-dialog-add.vue
@@ -278,7 +278,6 @@ article {
 .close-btn {
   position: absolute;
   top: -1.5vh;
-  cursor: pointer;
   right: -1.5vh;
   font-size: 4vh;
   transition: all 0.15s;

--- a/src/components/def-dialog-detail.vue
+++ b/src/components/def-dialog-detail.vue
@@ -285,7 +285,6 @@ article {
   right: -2.1vh;
   font-size: 4vh;
   color: #717171;
-  cursor: pointer;
 }
 .save-btn {
   position: absolute;
@@ -300,7 +299,6 @@ article {
   bottom: 3.1vh;
   color: #fff;
   text-align: center;
-  cursor: pointer;
   &:active {
     transition: all 0.2s;
     transform: translateX(-50%) scale(1.05);
@@ -313,7 +311,6 @@ article {
   font-size: 2vh;
   color: rgb(255, 98, 98);
   margin: 0;
-  cursor: pointer;
 }
 .edit-btn {
   position: absolute;
@@ -322,7 +319,6 @@ article {
   font-size: 2vh;
   color: rgb(102, 120, 223);
   margin: 0;
-  cursor: pointer;
 }
 .icon {
   font-size: 2.7vh;

--- a/src/components/def-nav.vue
+++ b/src/components/def-nav.vue
@@ -259,7 +259,6 @@ export default class Index extends Vue {
   color: #ffffff;
   border-radius: 1vh;
   font-size: 2.5vh;
-  cursor: pointer;
   &:active {
     transition: all 0.15s;
     transform: scale(1.05);

--- a/src/components/def-toolbar.vue
+++ b/src/components/def-toolbar.vue
@@ -54,7 +54,6 @@ export default class Index extends Vue {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  cursor: pointer;
   &:active {
     transform: translateY(-50%) scale(1.1);
   }
@@ -76,7 +75,6 @@ export default class Index extends Vue {
   right: 0;
   top: 50%;
   transform: translateY(-50%);
-  cursor: pointer;
   &:active {
     transform: translateY(-50%) scale(1.1);
   }

--- a/src/components/global/button.vue
+++ b/src/components/global/button.vue
@@ -27,7 +27,6 @@ export default class Index extends Vue {
   border-radius: 1vh;
   color: #fff;
   text-align: center;
-  cursor: pointer;
   &:active {
     transition: all 0.2s;
     transform: translateX(-50%) scale(1.05);


### PR DESCRIPTION
## 概要/目的
Androidでボタンをタップした時に青く光ってウェブ臭いので、光らないようにした
## やったこと・変更内容
pointer: cursorを消した
## 確認したこと

- [x] Chrome Android版で消えた

## 備考

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
