### PR TITLE
topのレイアウトを修正

### DIFF
--- a/src/components/app-table-contents.vue
+++ b/src/components/app-table-contents.vue
@@ -74,7 +74,6 @@ content {
   padding: 2vmin 2vw;
   box-shadow: 1vmin 1vmin 3vmin rgba(0, 0, 0, 0.226);
   border-radius: 10px;
-  top: 7vh;
 }
 
 //+++++++++++++++++++// 以下時間割の内容（中身） //++++++++++++++++++//

--- a/src/components/app-table-header.vue
+++ b/src/components/app-table-header.vue
@@ -73,38 +73,35 @@ $week-width: calc(
 );
 .s4 {
   display: block;
-  height: 7vh;
-  width: 9vh;
+  width: 15vw;
   font-size: 4.6vh;
   text-align: center;
 }
 #module {
-  position: absolute;
+  position: relative;
   display: flex;
+  justify-content: space-between;
   font-family: Noto Sans JP;
+  color: #9a9a9a;
   font-style: normal;
   font-weight: 500;
   font-size: 2.2vh;
   line-height: 4.6vh;
   width: 45vw;
-  color: #9a9a9a;
-  justify-content: space-between;
-  top: 8.5vh;
+  top: 0.5vh;
   left: 50%;
   transform: translateX(-50%);
 }
 #week {
-  position: absolute;
+  position: relative;
   display: flex;
   width: 87vw;
-  height: 3vh;
-  line-height: 3vh;
+  height: 2.5vh;
   font-family: Noto Sans JP;
   font-style: normal;
   font-weight: 500;
   font-size: 2vh;
   color: #9a9a9a;
-  top: 12.5vh;
 }
 .week-wrapper {
   position: absolute;
@@ -112,6 +109,6 @@ $week-width: calc(
   width: $week-width;
   justify-content: space-around;
   left: calc(13vw + 4vw);
-  top: 0.2vh;
+  top: 0.6vh;
 }
 </style>


### PR DESCRIPTION
## 概要/目的
#77 

## やったこと・変更内容
学期選択の矢印のwidthをvw指定に変更し、画面幅によって崩れていたレイアウトや下段に落ちていた文字を修正
webにおいて、ブラウザを縦にスクロールしたときに学期選択の部分や曜日だけ置いていかれる問題を修正
absolute指定の必要性がない箇所(#module,#day)をrelativeに変更

## 確認したこと

- [x] done
- [ ] not

## 備考

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
