### PR TITLE
文字サイズ変更機能、表示項目選択機能追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/__test__/store.visible.test.ts
+++ b/__test__/store.visible.test.ts
@@ -8,7 +8,13 @@ beforeEach(() => {
     drawer: false,
     detail: false,
     add: false,
-    table: { display: true, move: 'left' }
+    table: { display: true, move: 'left' },
+    subject: {
+      lecture_name: true,
+      lecture_code: true,
+      instructor: false,
+      room: true
+    }
   };
 });
 

--- a/__test__/store.visible.test.ts
+++ b/__test__/store.visible.test.ts
@@ -13,7 +13,8 @@ beforeEach(() => {
       lecture_name: true,
       lecture_code: true,
       instructor: false,
-      room: true
+      room: true,
+      font_size: 'medium'
     }
   };
 });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -55,10 +55,10 @@ const nuxtConfig: Configuration = {
     ]
   },
   loadingIndicator: {
-    name: 'wandering-cubes',
+    name: 'cube-grid',
     color: 'teal',
-    color2: 'white',
-    background: 'gray'
+    color2: 'grey',
+    background: 'white'
   },
   loading: {
     color: 'teal',

--- a/src/components/def-nav.vue
+++ b/src/components/def-nav.vue
@@ -64,9 +64,9 @@ export default class Index extends Vue {
 
   list = [
     { icon: 'home', name: 'ホームへ戻る', link: '/' },
-    { icon: 'help', name: '使い方', link: 'https://www.twinte.net/howto' }
+    { icon: 'help', name: '使い方', link: 'https://www.twinte.net/howto' },
     // , { icon: "supervisor_account", name: "About", link: "/about" }
-    // , { icon: "view_quilt", name: "表示設定", link: "/settings" }
+    { icon: 'view_quilt', name: '表示設定', link: '/display-settings' }
     // , { icon: "share", name: "時間割の共有", link: "/" }
     // { icon: 'delete_sweep', name: '時間割データの消去', link: 'func:delete' }
   ];

--- a/src/components/global/button.vue
+++ b/src/components/global/button.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="btn" :style="{ width, height }">{{ text }}</div>
+  <button class="btn" :style="{ width, height }">{{ text }}</button>
 </template>
 
 <script lang="ts">
@@ -15,21 +15,24 @@ export default class Index extends Vue {
 
 <style scoped lang="scss">
 .btn {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 100%;
-  max-width: 550px;
+  /* buttonのcssリセット */
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  outline: none;
+  padding: 0;
+  appearance: none;
+
   font-size: 2.3vh;
-  height: 6vh;
   line-height: 6vh;
   background: #00c0c0;
   border-radius: 1vh;
+  bottom: 0;
   color: #fff;
   text-align: center;
   &:active {
     transition: all 0.2s;
-    transform: translateX(-50%) scale(1.05);
+    transform: scale(1.05);
     background-color: #05dbdb;
   }
 }

--- a/src/components/ui-subject.vue
+++ b/src/components/ui-subject.vue
@@ -3,18 +3,15 @@
     <div id="subject" v-if="!table"></div>
     <!-- → 授業が入っていない -->
 
-    <div
-      id="subject"
-      :style="{
-        background: getColor(table.lecture_code)
-      }"
-      v-else
-    >
+    <div id="subject" :style="setSubjectStyle()" v-else>
       <div v-if="display.lecture_code" class="sbj-lectureId">
         {{ table.lecture_code }}
       </div>
       <div v-if="display.lecture_name" class="sbj-name">
         {{ table.lecture_name }}
+      </div>
+      <div v-if="display.instructor" class="sbj-instructor">
+        {{ table.instructor }}
       </div>
       <div v-if="display.room" class="sbj-room">{{ table.room }}</div>
     </div>
@@ -76,6 +73,29 @@ export default class Index extends Vue {
   get module() {
     return this.$store.getters['table/module'];
   }
+  setSubjectStyle() {
+    switch (this.display.font_size) {
+      case 'small':
+        return {
+          background: this.getColor(this.table?.lecture_code),
+          fontSize: '1vh',
+          lineHeight: '2vh'
+        };
+      case 'medium':
+        return {
+          background: this.getColor(this.table?.lecture_code),
+          fontSize: '1.3vh',
+          lineHeight: '2vh'
+        };
+      default:
+        // 'large'
+        return {
+          background: this.getColor(this.table?.lecture_code),
+          fontSize: '1.9vh',
+          lineHeight: '2vh'
+        };
+    }
+  }
   chDetail(period: Period) {
     this.$store.dispatch('table/setPeriod', { period });
     this.$store.commit('visible/chDetail', { display: true });
@@ -87,6 +107,7 @@ export default class Index extends Vue {
     if (this.click === 'disable') {
       return;
     }
+    // 設定画面ではclickできない
 
     if (this.table) {
       this.chDetail(this.table);
@@ -95,7 +116,7 @@ export default class Index extends Vue {
     }
   }
   /** 授業に応じたテーマ色を返す */
-  getColor(number: string): string {
+  getColor(number: string | undefined): string {
     if (!number) {
       return '#EEEEEE';
     }
@@ -131,8 +152,6 @@ $width: calc(
   word-break: break-all;
   font-style: normal;
   font-weight: 700;
-  font-size: 1.3vh;
-  line-height: 2vh;
   overflow: hidden;
   &:active {
     transition: all 0.3s;
@@ -144,6 +163,9 @@ $width: calc(
 }
 .sbj-name {
   font-weight: 700;
+}
+.sbj-instructor {
+  font-weight: 400;
 }
 .sbj-room {
   font-weight: 400;

--- a/src/components/ui-subject.vue
+++ b/src/components/ui-subject.vue
@@ -78,21 +78,18 @@ export default class Index extends Vue {
       case 'small':
         return {
           background: this.getColor(this.table?.lecture_code),
-          fontSize: '1vh',
-          lineHeight: '2vh'
+          fontSize: '1.4vh'
         };
       case 'medium':
         return {
           background: this.getColor(this.table?.lecture_code),
-          fontSize: '1.3vh',
-          lineHeight: '2vh'
+          fontSize: '1.57vh'
         };
       default:
-        // 'large'
+        'large';
         return {
           background: this.getColor(this.table?.lecture_code),
-          fontSize: '1.9vh',
-          lineHeight: '2vh'
+          fontSize: '1.8vh'
         };
     }
   }
@@ -153,6 +150,7 @@ $width: calc(
   font-style: normal;
   font-weight: 700;
   overflow: hidden;
+  line-height: 2vh;
   &:active {
     transition: all 0.3s;
     filter: brightness(150%);

--- a/src/components/ui-subject.vue
+++ b/src/components/ui-subject.vue
@@ -78,18 +78,21 @@ export default class Index extends Vue {
       case 'small':
         return {
           background: this.getColor(this.table?.lecture_code),
-          fontSize: '1.4vh'
+          fontSize: '1.4vh',
+          lineHeight: '2vh'
         };
       case 'medium':
         return {
           background: this.getColor(this.table?.lecture_code),
-          fontSize: '1.57vh'
+          fontSize: '1.57vh',
+          lineHeight: '2.2vh'
         };
       default:
         'large';
         return {
           background: this.getColor(this.table?.lecture_code),
-          fontSize: '1.8vh'
+          fontSize: '1.8vh',
+          lineHeight: '2.4vh'
         };
     }
   }
@@ -150,7 +153,6 @@ $width: calc(
   font-style: normal;
   font-weight: 700;
   overflow: hidden;
-  line-height: 2vh;
   &:active {
     transition: all 0.3s;
     filter: brightness(150%);

--- a/src/components/ui-subject.vue
+++ b/src/components/ui-subject.vue
@@ -10,9 +10,13 @@
       }"
       v-else
     >
-      <div class="sbj-lectureId">{{ table.lecture_code }}</div>
-      <div class="sbj-name">{{ table.lecture_name }}</div>
-      <div class="sbj-room">{{ table.room }}</div>
+      <div v-if="display.lecture_code" class="sbj-lectureId">
+        {{ table.lecture_code }}
+      </div>
+      <div v-if="display.lecture_name" class="sbj-name">
+        {{ table.lecture_name }}
+      </div>
+      <div v-if="display.room" class="sbj-room">{{ table.room }}</div>
     </div>
     <!-- → 授業が入っている -->
   </section>
@@ -40,10 +44,20 @@ export default class Index extends Vue {
 
   @Prop() day!: number;
   @Prop() period!: number;
+  @Prop() data!: Period | undefined;
+  @Prop() click!: string | undefined;
 
   week: string[] = [Day.Mon, Day.Tue, Day.Wed, Day.Thu, Day.Fri];
 
+  get display() {
+    return this.$store.getters['visible/subject'];
+  }
+
   get table() {
+    if (this.data) {
+      return this.data;
+    }
+
     const periods = this.$store.getters['api/table'];
     const module = this.module;
     const week = this.week;
@@ -70,6 +84,10 @@ export default class Index extends Vue {
     this.$store.commit('visible/chAdd', { display: true });
   }
   popUp() {
+    if (this.click === 'disable') {
+      return;
+    }
+
     if (this.table) {
       this.chDetail(this.table);
     } else {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -66,6 +66,7 @@ export default class Index extends Vue {
     if (subject) {
       this.$store.commit('visible/setDisplaySubject', JSON.parse(subject));
     }
+    // → 表示設定
 
     const loginFlag = localStorage.getItem('login');
     if (!loginFlag && loginState) {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -62,6 +62,11 @@ export default class Index extends Vue {
     }
     // → 前回見ていた学期
 
+    const subject = localStorage.getItem('subject');
+    if (subject) {
+      this.$store.commit('visible/setDisplaySubject', JSON.parse(subject));
+    }
+
     const loginFlag = localStorage.getItem('login');
     if (!loginFlag && loginState) {
       Swal.fire(

--- a/src/pages/display-settings.vue
+++ b/src/pages/display-settings.vue
@@ -1,0 +1,85 @@
+<template>
+  <div>
+    <h2>表示する項目</h2>
+    <label
+      >教科名<input
+        v-model="subject.lecture_name"
+        type="checkbox"
+        name="lecture_name"
+        id="lecture_name"
+    /></label>
+    <label
+      >教科番号<input
+        v-model="subject.lecture_code"
+        type="checkbox"
+        name="lecture_number"
+        id="lecture_number"
+    /></label>
+    <label
+      >教師名<input
+        v-model="subject.instructor"
+        type="checkbox"
+        name="instructor"
+        id="instructor"
+    /></label>
+    <label
+      >教室名<input v-model="subject.room" type="checkbox" name="room" id="room"
+    /></label>
+    <Subject :data="sampleData" click="disable" />
+
+    <h2>文字の大きさ</h2>
+    <label><input v-model="font_size" type="radio" value="small" />小</label>
+    <label><input v-model="font_size" type="radio" value="medium" />中</label>
+    <label><input v-model="font_size" type="radio" value="large" />大</label>
+    <button @click="setSubject()">保存</button>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator';
+import * as Vuex from 'vuex';
+import { Period } from '../types';
+import cloneDeep from 'lodash/cloneDeep';
+
+@Component({
+  components: {
+    Subject: () => import('~/components/ui-subject.vue'),
+    TButton: () => import('~/components/global/button.vue')
+  }
+})
+export default class Index extends Vue {
+  $store!: Vuex.ExStore;
+
+  subject = {
+    lecture_name: false,
+    lecture_code: false,
+    instructor: false,
+    room: false
+  };
+  font_size = 'medium';
+
+  sampleData: Period = {
+    lecture_code: 'GB11514',
+    lecture_name: 'シミュレーション物理',
+    instructor: '都市樹',
+    year: 2019,
+    module: '秋C',
+    day: '木',
+    period: 4,
+    room: '3C313',
+    user_lecture_id: 'sampledata'
+  };
+
+  setSubject() {
+    this.$store.commit('visible/setDisplaySubject', this.subject);
+    this.subject = cloneDeep(this.$store.getters['visible/subject']);
+    localStorage.setItem('subject', JSON.stringify(this.subject));
+  }
+
+  mounted() {
+    this.subject = cloneDeep(this.$store.getters['visible/subject']);
+  }
+}
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/pages/display-settings.vue
+++ b/src/pages/display-settings.vue
@@ -1,44 +1,93 @@
 <template>
-  <div>
-    <h2>表示する項目</h2>
-    <label
-      >教科名<input
-        v-model="sbj.lecture_name"
-        type="checkbox"
-        name="lecture_name"
-        id="lecture_name"
-    /></label>
-    <label
-      >教科番号<input
-        v-model="sbj.lecture_code"
-        type="checkbox"
-        name="lecture_number"
-        id="lecture_number"
-    /></label>
-    <label
-      >教師名<input
-        v-model="sbj.instructor"
-        type="checkbox"
-        name="instructor"
-        id="instructor"
-    /></label>
-    <label
-      >教室名<input v-model="sbj.room" type="checkbox" name="room" id="room"
-    /></label>
-    <Subject :data="sampleData" click="disable" />
+  <main class="display-settings">
+    <h1>表示設定</h1>
+    <div class="setting-card">
+      <h2>時間割表の設定</h2>
+      <div class="preview-flex">
+        <section class="visible-setting">
+          <h3>表示する項目</h3>
+          <ul>
+            <li>
+              <input
+                @change="setSbj()"
+                v-model="sbj.lecture_code"
+                type="checkbox"
+                name="lecture_number"
+                id="lecture_number"
+                class="setting-checkbox"
+              />
+              <label class="display-check" for="lecture_number"
+                ><span></span></label
+              >科目番号
+            </li>
+            <li>
+              <input
+                @change="setSbj()"
+                v-model="sbj.instructor"
+                type="checkbox"
+                name="instructor"
+                id="instructor"
+                class="setting-checkbox"
+              />
+              <label class="display-check" for="instructor"><span></span></label
+              >担当教員
+            </li>
+            <li>
+              <input
+                @change="setSbj()"
+                v-model="sbj.room"
+                type="checkbox"
+                name="room"
+                id="room"
+                class="setting-checkbox"
+              />
+              <label class="display-check" for="room"><span></span></label
+              >教室名
+            </li>
+          </ul>
+        </section>
 
-    <h2>文字の大きさ</h2>
-    <label
-      ><input v-model="sbj.font_size" type="radio" value="small" />小</label
-    >
-    <label
-      ><input v-model="sbj.font_size" type="radio" value="medium" />中</label
-    >
-    <label
-      ><input v-model="sbj.font_size" type="radio" value="large" />大</label
-    >
-    <button @click="setSbj()">保存</button>
-  </div>
+        <!-- 時間割表のプレビュー -->
+        <div class="preview-wrap">
+          <Subject class="subject" :data="sampleData" click="disable" />
+        </div>
+      </div>
+
+      <section class="fontsize-setting">
+        <h3>文字の大きさ</h3>
+        <div class="fontsizebtn-flex">
+          <label
+            ><input
+              @change="setSbj()"
+              v-model="sbj.font_size"
+              type="radio"
+              value="small"
+              class="setting-radio"
+            /><span class="fontsize-btn">小</span></label
+          >
+          <label
+            ><input
+              @change="setSbj()"
+              v-model="sbj.font_size"
+              type="radio"
+              value="medium"
+              class="setting-radio"
+            /><span class="fontsize-btn">中</span></label
+          >
+          <label
+            ><input
+              @change="setSbj()"
+              v-model="sbj.font_size"
+              type="radio"
+              value="large"
+              class="setting-radio"
+            /><span class="fontsize-btn">大</span></label
+          >
+        </div>
+        <!-- <button @click="setSbj()">保存</button> -->
+      </section>
+    </div>
+  </main>
 </template>
 
 <script lang="ts">
@@ -65,14 +114,14 @@ export default class Index extends Vue {
   };
 
   sampleData: Period = {
-    lecture_code: 'GB11514',
-    lecture_name: 'シミュレーション物理',
-    instructor: '都市樹',
+    lecture_code: '0A00000',
+    lecture_name: '科目名',
+    instructor: '担当教員',
     year: 2019,
     module: '秋C',
     day: '木',
     period: 4,
-    room: '3C313',
+    room: '0A000',
     user_lecture_id: 'sampledata'
   };
 
@@ -88,4 +137,124 @@ export default class Index extends Vue {
 }
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.display-settings {
+  color: #555555;
+  padding: 1vh 6vw;
+  max-width: 70vh;
+  margin: 0 auto;
+}
+h1 {
+  font-size: 3vh;
+  font-weight: 500;
+}
+.setting-card {
+  background-color: white;
+  border-radius: 1vh;
+  box-shadow: 1vmin 1vmin 3vmin rgba(0, 0, 0, 0.349);
+  margin: 1vh auto 2vh auto;
+  padding: 3vh 3vh 1vh;
+}
+.visible-setting {
+  width: 42%;
+  ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+  }
+  li {
+    font-size: 2.5vh;
+    line-height: 2.3 * 2.7vh;
+  }
+}
+.preview-flex {
+  display: flex;
+  justify-content: flex-start;
+}
+.preview-wrap {
+  position: relative;
+}
+.subject {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+section {
+  margin: 3vh 2.5vh;
+}
+
+h2 {
+  font-size: 3vh;
+  color: #00c0c0;
+  font-weight: 500;
+  margin: 0 0 2vh;
+}
+
+h3 {
+  font-size: 2.3vh;
+  font-weight: 500;
+  margin: 0 0 1vh;
+}
+
+.display-check {
+  margin-right: 3%;
+  vertical-align: middle;
+  display: inline-block;
+  position: relative;
+  border: 0.25vh solid #9a9a9a;
+  border-radius: 50% 50%;
+  width: 3.3vh;
+  height: 3.3vh;
+  span {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateY(-50%) translateX(-50%);
+    width: 2.5vh;
+    height: 2.5vh;
+    border-radius: 50% 50%;
+    opacity: 0;
+  }
+}
+
+.setting-checkbox:checked ~ .display-check {
+  border: 0.25vh solid #00c0c0;
+  span {
+    opacity: 1;
+    background-color: #00c0c0;
+  }
+}
+
+input {
+  display: none;
+}
+
+.fontsize-setting {
+  .fontsizebtn-flex {
+    display: flex;
+    vertical-align: middle;
+    justify-content: flex-start;
+    margin: 2vh 0;
+  }
+
+  .fontsize-btn {
+    display: block;
+    border: #00c0c0 0.2vh solid;
+    border-radius: 400px;
+    width: 10vh;
+    height: 5vh;
+    line-height: 5vh;
+    text-align: center;
+    color: #00c0c0;
+    margin-right: 3vh;
+    :nth-child(1) {
+      font-size: 1.9vh;
+    }
+  }
+  .setting-radio:checked ~ .fontsize-btn {
+    background-color: #00c0c0;
+    color: white;
+  }
+}
+</style>

--- a/src/pages/display-settings.vue
+++ b/src/pages/display-settings.vue
@@ -147,16 +147,24 @@ export default class Index extends Vue {
 h1 {
   font-size: 3vh;
   font-weight: 500;
+  margin-bottom: 2vh;
 }
 .setting-card {
   background-color: white;
   border-radius: 1vh;
   box-shadow: 1vmin 1vmin 3vmin rgba(0, 0, 0, 0.349);
   margin: 1vh auto 2vh auto;
-  padding: 3vh 3vh 1vh;
+  padding: 3vh 5vmin;
+}
+
+.preview-flex {
+  display: flex;
+  justify-content: flex-start;
 }
 .visible-setting {
-  width: 42%;
+  width: 45%;
+  margin-bottom: 3vh;
+  padding-left: 2vmin;
   ul {
     list-style: none;
     padding-left: 0;
@@ -167,28 +175,23 @@ h1 {
     line-height: 2.3 * 2.7vh;
   }
 }
-.preview-flex {
-  display: flex;
-  justify-content: flex-start;
-}
 .preview-wrap {
   position: relative;
+  width: 46%;
 }
 .subject {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-section {
-  margin: 3vh 2.5vh;
+  top: 46%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-50%);
+  -ms-wrap-margin: 0;
 }
 
 h2 {
-  font-size: 3vh;
+  font-size: 2.7vh;
   color: #00c0c0;
   font-weight: 500;
-  margin: 0 0 2vh;
+  margin: 0 0 3vh;
 }
 
 h3 {
@@ -231,26 +234,34 @@ input {
 }
 
 .fontsize-setting {
+  padding-left: 2vmin;
   .fontsizebtn-flex {
     display: flex;
     vertical-align: middle;
     justify-content: flex-start;
-    margin: 2vh 0;
+    margin-top: 2vh;
   }
 
   .fontsize-btn {
     display: block;
     border: #00c0c0 0.2vh solid;
     border-radius: 400px;
-    width: 10vh;
-    height: 5vh;
-    line-height: 5vh;
+    width: 9vh;
+    height: 4.5vh;
+    line-height: 4.5vh;
     text-align: center;
     color: #00c0c0;
+    background-color: white;
     margin-right: 3vh;
-    :nth-child(1) {
-      font-size: 1.9vh;
-    }
+  }
+  label:nth-child(1) {
+    font-size: 1.9vh;
+  }
+  label:nth-child(2) {
+    font-size: 2.3vh;
+  }
+  label:nth-child(3) {
+    font-size: 2.7vh;
   }
   .setting-radio:checked ~ .fontsize-btn {
     background-color: #00c0c0;

--- a/src/pages/display-settings.vue
+++ b/src/pages/display-settings.vue
@@ -3,42 +3,48 @@
     <h2>表示する項目</h2>
     <label
       >教科名<input
-        v-model="subject.lecture_name"
+        v-model="sbj.lecture_name"
         type="checkbox"
         name="lecture_name"
         id="lecture_name"
     /></label>
     <label
       >教科番号<input
-        v-model="subject.lecture_code"
+        v-model="sbj.lecture_code"
         type="checkbox"
         name="lecture_number"
         id="lecture_number"
     /></label>
     <label
       >教師名<input
-        v-model="subject.instructor"
+        v-model="sbj.instructor"
         type="checkbox"
         name="instructor"
         id="instructor"
     /></label>
     <label
-      >教室名<input v-model="subject.room" type="checkbox" name="room" id="room"
+      >教室名<input v-model="sbj.room" type="checkbox" name="room" id="room"
     /></label>
     <Subject :data="sampleData" click="disable" />
 
     <h2>文字の大きさ</h2>
-    <label><input v-model="font_size" type="radio" value="small" />小</label>
-    <label><input v-model="font_size" type="radio" value="medium" />中</label>
-    <label><input v-model="font_size" type="radio" value="large" />大</label>
-    <button @click="setSubject()">保存</button>
+    <label
+      ><input v-model="sbj.font_size" type="radio" value="small" />小</label
+    >
+    <label
+      ><input v-model="sbj.font_size" type="radio" value="medium" />中</label
+    >
+    <label
+      ><input v-model="sbj.font_size" type="radio" value="large" />大</label
+    >
+    <button @click="setSbj()">保存</button>
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'nuxt-property-decorator';
 import * as Vuex from 'vuex';
-import { Period } from '../types';
+import { Period, SubjectSettings } from '../types';
 import cloneDeep from 'lodash/cloneDeep';
 
 @Component({
@@ -50,13 +56,13 @@ import cloneDeep from 'lodash/cloneDeep';
 export default class Index extends Vue {
   $store!: Vuex.ExStore;
 
-  subject = {
+  sbj: SubjectSettings = {
     lecture_name: false,
     lecture_code: false,
     instructor: false,
-    room: false
+    room: false,
+    font_size: 'medium'
   };
-  font_size = 'medium';
 
   sampleData: Period = {
     lecture_code: 'GB11514',
@@ -70,14 +76,14 @@ export default class Index extends Vue {
     user_lecture_id: 'sampledata'
   };
 
-  setSubject() {
-    this.$store.commit('visible/setDisplaySubject', this.subject);
-    this.subject = cloneDeep(this.$store.getters['visible/subject']);
-    localStorage.setItem('subject', JSON.stringify(this.subject));
+  setSbj() {
+    this.$store.commit('visible/setDisplaySubject', this.sbj);
+    this.sbj = cloneDeep(this.$store.getters['visible/subject']);
+    localStorage.setItem('subject', JSON.stringify(this.sbj));
   }
 
   mounted() {
-    this.subject = cloneDeep(this.$store.getters['visible/subject']);
+    this.sbj = cloneDeep(this.$store.getters['visible/subject']);
   }
 }
 </script>

--- a/src/store/visible/index.ts
+++ b/src/store/visible/index.ts
@@ -11,7 +11,7 @@ export const state = (): S => ({
     lecture_code: false,
     instructor: false,
     room: true,
-    font_size: 'medium'
+    font_size: 'small'
   }
 });
 

--- a/src/store/visible/index.ts
+++ b/src/store/visible/index.ts
@@ -5,14 +5,21 @@ export const state = (): S => ({
   drawer: false,
   detail: false,
   add: false,
-  table: { display: true, move: 'left' }
+  table: { display: true, move: 'left' },
+  subject: {
+    lecture_name: true,
+    lecture_code: true,
+    instructor: false,
+    room: true
+  }
 });
 
 export const getters: Getters<S, G> = {
   drawer: state => state.drawer,
   detail: state => state.detail,
   add: state => state.add,
-  table: state => state.table
+  table: state => state.table,
+  subject: state => state.subject
 };
 
 export const mutations: Mutations<S, M> = {
@@ -27,5 +34,8 @@ export const mutations: Mutations<S, M> = {
   },
   chTable(state, payload) {
     state.table = payload;
+  },
+  setDisplaySubject(state, payload) {
+    state.subject = payload;
   }
 };

--- a/src/store/visible/index.ts
+++ b/src/store/visible/index.ts
@@ -8,9 +8,10 @@ export const state = (): S => ({
   table: { display: true, move: 'left' },
   subject: {
     lecture_name: true,
-    lecture_code: true,
+    lecture_code: false,
     instructor: false,
-    room: true
+    room: true,
+    font_size: 'medium'
   }
 });
 

--- a/src/store/visible/type.ts
+++ b/src/store/visible/type.ts
@@ -9,18 +9,14 @@
  * - table: 時間割。アニメーション時に状態を変えます
  *
  */
+import { SubjectSettings } from '../../types';
 
 export interface S {
   drawer: boolean;
   detail: boolean;
   add: boolean;
   table: { display: boolean; move: 'left' | 'right' };
-  subject: {
-    lecture_name: boolean;
-    lecture_code: boolean;
-    instructor: boolean;
-    room: boolean;
-  };
+  subject: SubjectSettings;
 }
 export interface G {
   /**
@@ -39,12 +35,7 @@ export interface G {
    * 時間割 アニメーション実装するため、どちら遷移するかmoveで記述
    */
   table: { display: boolean; move: 'left' | 'right' };
-  subject: {
-    lecture_name: boolean;
-    lecture_code: boolean;
-    instructor: boolean;
-    room: boolean;
-  };
+  subject: SubjectSettings;
 }
 export interface RG {
   'visible/drawer': G['drawer'];
@@ -75,12 +66,7 @@ export interface M {
    * @param move "left" "right" アニメーション実装するため、どちら遷移するか記述
    */
   chTable: { display: boolean; move: 'left' | 'right' };
-  setDisplaySubject: {
-    lecture_name: boolean;
-    lecture_code: boolean;
-    instructor: boolean;
-    room: boolean;
-  };
+  setDisplaySubject: SubjectSettings;
 }
 export interface RM {
   'visible/chDrawer': M['chDrawer'];

--- a/src/store/visible/type.ts
+++ b/src/store/visible/type.ts
@@ -15,6 +15,12 @@ export interface S {
   detail: boolean;
   add: boolean;
   table: { display: boolean; move: 'left' | 'right' };
+  subject: {
+    lecture_name: boolean;
+    lecture_code: boolean;
+    instructor: boolean;
+    room: boolean;
+  };
 }
 export interface G {
   /**
@@ -33,12 +39,19 @@ export interface G {
    * 時間割 アニメーション実装するため、どちら遷移するかmoveで記述
    */
   table: { display: boolean; move: 'left' | 'right' };
+  subject: {
+    lecture_name: boolean;
+    lecture_code: boolean;
+    instructor: boolean;
+    room: boolean;
+  };
 }
 export interface RG {
   'visible/drawer': G['drawer'];
   'visible/detail': G['detail'];
   'visible/add': G['add'];
   'visible/table': G['table'];
+  'visible/subject': G['subject'];
 }
 export interface M {
   /**
@@ -62,10 +75,17 @@ export interface M {
    * @param move "left" "right" アニメーション実装するため、どちら遷移するか記述
    */
   chTable: { display: boolean; move: 'left' | 'right' };
+  setDisplaySubject: {
+    lecture_name: boolean;
+    lecture_code: boolean;
+    instructor: boolean;
+    room: boolean;
+  };
 }
 export interface RM {
   'visible/chDrawer': M['chDrawer'];
   'visible/chDetail': M['chDetail'];
   'visible/chAdd': M['chAdd'];
   'visible/chTable': M['chTable'];
+  'visible/setDisplaySubject': M['setDisplaySubject'];
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -24,4 +24,12 @@ type OutputSearchData = {
   instructor: string;
 }[];
 
-export { Day, Module, TimeTables, Period, OutputSearchData };
+type SubjectSettings = {
+  lecture_name: boolean;
+  lecture_code: boolean;
+  instructor: boolean;
+  room: boolean;
+  font_size: 'small' | 'medium' | 'large';
+};
+
+export { Day, Module, TimeTables, Period, OutputSearchData, SubjectSettings };


### PR DESCRIPTION
## 概要/目的
時間割表の文字サイズと表示項目をユーザー自身で設定できるようになりました。

## やったこと・変更内容
#94 #97 
「表示設定」項目として、時間割表の文字サイズを3段階で変更する機能と、表示する項目（科目番号・教室番号・教員名）を選択する機能を追加

## 確認したこと
- [x] 設定事項が時間割ページに反映されること
- [x] 表示設定画面に設置したプレビュー（１コマ分のサンプル）にも反映されること

## 備考

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
