### PR TITLE
ダイアログのスタイル修正

### DIFF
--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -1,55 +1,59 @@
-$material-icons-font-path: "~material-icons/iconfont/";
-$material-icons-font-path: "" !default;
-$material-icons-font-name: "MaterialIcons-Regular" !default;
-$material-icons-font-family: "Material Icons" !default;
-@import url("https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,500,700&display=swap&subset=japanese");
-@import "~material-icons/iconfont/material-icons.scss";
-@import "normalize.css/normalize.css";
-html{
-    overflow-y: hidden;
-    height:100%;
+$material-icons-font-path: '~material-icons/iconfont/';
+$material-icons-font-path: '' !default;
+$material-icons-font-name: 'MaterialIcons-Regular' !default;
+$material-icons-font-family: 'Material Icons' !default;
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,500,700&display=swap&subset=japanese');
+@import '~material-icons/iconfont/material-icons.scss';
+@import 'normalize.css/normalize.css';
+
+:root {
+  --outer-height: 100vh;
+}
+
+html {
+  overflow-y: hidden;
+  height: 100%;
 }
 body {
-    height:100%;
-    overflow-x: hidden;
-    font-family: "Noto Sans JP";
+  height: 100%;
+  overflow-x: hidden;
+  font-family: 'Noto Sans JP';
 }
 
 .svg-button {
-    border: none;
-    background: none;
-    transition: transform 0.3s liner;
-    &:focus {
-        outline: 2px dashed #17171d;
-    }
-    &:hover {
-        transform: scale(1.1);
-    }
-    &:active {
-        transform: scale(1.2);
-    }
+  border: none;
+  background: none;
+  transition: transform 0.3s liner;
+  &:focus {
+    outline: 2px dashed #17171d;
+  }
+  &:hover {
+    transform: scale(1.1);
+  }
+  &:active {
+    transform: scale(1.2);
+  }
 }
-
 
 /** animation */
 
 .bound-enter-active,
 .bound-leave-active {
-    transition: all 0.1s ease-in;
+  transition: all 0.1s ease-in;
 }
 
 .bound-enter,
 .bound-leave-to {
-    transform: scale(0.9);
-    opacity: 0;
+  transform: scale(0.9);
+  opacity: 0;
 }
 
 .fade-enter-active,
 .fade-leave-active {
-    transition: all 0.1s ease-in;
+  transition: all 0.1s ease-in;
 }
 
 .fade-enter,
 .fade-leave-to {
-    opacity: 0;
+  opacity: 0;
 }

--- a/src/components/def-dialog-add.vue
+++ b/src/components/def-dialog-add.vue
@@ -45,7 +45,7 @@
           <!-- ここまで検索結果 -->
 
           <section class="others">
-            <p v-if="isMobile" class="content" @click="twins()">
+            <p class="content" @click="twins()">
               Twinsからインポート
               <span class="material-icons icon">chevron_right</span>
             </p>
@@ -122,7 +122,17 @@ export default class Index extends Vue {
     this.$store.commit('visible/chAdd', { display: false });
   }
   twins() {
-    twinsToTwinteAlert();
+    console.log(this.isMobile);
+
+    if (this.isMobile) {
+      twinsToTwinteAlert();
+    } else {
+      Swal.fire(
+        'ご利用の環境では非対応です',
+        'この機能はiOS版アプリ・Android版アプリでのみ利用できます。',
+        'info'
+      );
+    }
   }
   custom() {
     this.$router.push('/custom');
@@ -133,7 +143,7 @@ export default class Index extends Vue {
     if (!le || le.length === 0) {
       Swal.fire(
         '見つかりません',
-        '検索しましたが何も見つかりませんでした',
+        '検索しましたが何も見つかりませんでした' /*宿題やったんですけど家に忘れてきました*/,
         'error'
       );
       return;
@@ -326,7 +336,7 @@ h1 {
 /** 検索結果 */
 .result-list {
   width: 100%;
-  height: 35vh;
+  height: 36vh;
   margin: 1.5vh 0;
   padding: 1vw 0.5vw;
   overflow-y: scroll;
@@ -346,6 +356,7 @@ h1 {
   width: 100%;
 }
 .content {
+  margin: 1vh;
   font-size: 2vh;
   color: #9a9a9a;
   margin-left: 0.5vh;
@@ -362,7 +373,7 @@ h1 {
 //++++++++++++++++++++++++// 保存ボタン //++++++++++++++++++++++++//
 .save-btn {
   display: block;
-  margin: 0 auto;
+  margin: 2vh auto 0;
   color: #fff;
   width: 100%;
   height: 6vh;

--- a/src/components/def-dialog-add.vue
+++ b/src/components/def-dialog-add.vue
@@ -7,7 +7,9 @@
     <transition name="bound">
       <nav class="main" v-show="add">
         <article>
-          <div class="svg-button material-icons close-btn" @click="chAdd()">close</div>
+          <div class="svg-button material-icons close-btn" @click="chAdd()">
+            close
+          </div>
           <h1>授業の追加</h1>
 
           <!-- 検索フォーム -->
@@ -19,8 +21,18 @@
               class="form"
               　@keyup.enter="search(input)"
             />
-            <span v-if="input === ''" @click="lectures = []" class="material-icons search-btn">close</span>
-            <span v-else @click="search(input)" class="material-icons search-btn">search</span>
+            <span
+              v-if="input === ''"
+              @click="lectures = []"
+              class="material-icons search-btn"
+              >close</span
+            >
+            <span
+              v-else
+              @click="search(input)"
+              class="material-icons search-btn"
+              >search</span
+            >
           </form>
 
           <!-- 以下検索結果 -->
@@ -66,7 +78,9 @@
             <!-- <p @click="custom()">手動入力で授業を作成</p> -->
           </section>
           <!-- → その他オプション -->
-          <section class="save-btn" @click="asyncNumber()">時間割に追加</section>
+          <section class="save-btn" @click="asyncNumber()">
+            時間割に追加
+          </section>
         </article>
       </nav>
     </transition>

--- a/src/components/def-dialog-add.vue
+++ b/src/components/def-dialog-add.vue
@@ -15,7 +15,7 @@
             <input
               v-model="input"
               type="text"
-              value="授業名・科目番号で検索"
+              placeholder="授業名や科目番号で検索"
               class="form"
               　@keyup.enter="search(input)"
             />
@@ -286,8 +286,8 @@ h1 {
     height: 100%;
     width: 100%;
     background-color: #fff;
-    border: 0.2vh solid #adadad;
-    color: #4a5568;
+    border: 0.2vh solid #9a9a9a;
+    color: #555555;
     border-radius: 3vh;
     position: relative;
     margin: 0;
@@ -295,6 +295,11 @@ h1 {
     padding-left: 3%;
     font-size: 16px;
     box-sizing: border-box;
+  }
+  ::placeholder {
+    color: #9a9a9a;
+    font-size: 14px;
+    padding-top: 4px;
   }
   .search-btn {
     position: absolute;

--- a/src/components/def-dialog-add.vue
+++ b/src/components/def-dialog-add.vue
@@ -7,37 +7,23 @@
     <transition name="bound">
       <nav class="main" v-show="add">
         <article>
-          <div class="svg-button material-icons close-btn" @click="chAdd()">
-            close
-          </div>
+          <div class="svg-button material-icons close-btn" @click="chAdd()">close</div>
           <h1>授業の追加</h1>
-          <p class="content">科目名・授業番号で検索</p>
-          <p v-if="isMobile" class="twins-btn" @click="twins()">
-            Twinsからインポート
-          </p>
 
+          <!-- 検索フォーム -->
           <form class="search-form" @submit.prevent>
             <input
               v-model="input"
               type="text"
+              value="授業名・科目番号で検索"
               class="form"
-              @keyup.enter="search(input)"
+              　@keyup.enter="search(input)"
             />
-            <span
-              v-if="input === ''"
-              @click="lectures = []"
-              class="material-icons search-btn"
-              >close</span
-            >
-            <span
-              v-else
-              @click="search(input)"
-              class="material-icons search-btn"
-              >search</span
-            >
+            <span v-if="input === ''" @click="lectures = []" class="material-icons search-btn">close</span>
+            <span v-else @click="search(input)" class="material-icons search-btn">search</span>
           </form>
-          <!-- → 検索ボックス -->
 
+          <!-- 以下検索結果 -->
           <section class="result-list">
             <div
               v-for="(n, i) in lectures"
@@ -56,28 +42,31 @@
               </label>
             </div>
           </section>
-          <!-- → 検索結果 -->
+          <!-- ここまで検索結果 -->
 
           <section class="others">
-            <p>
+            <p v-if="isMobile" class="content" @click="twins()">
+              Twinsからインポート
+              <span class="material-icons icon">chevron_right</span>
+            </p>
+            <p class="content">
               CSVファイルから追加
               <br />
               <small>*{{ moduleMessage }}</small>
+              <input
+                type="file"
+                name="file"
+                accept="text/csv, .csv"
+                id="fileElem"
+                @change="onFileChange"
+                class="add-csv"
+              />
             </p>
-            <input
-              type="file"
-              name="file"
-              accept="text/csv, .csv"
-              id="fileElem"
-              @change="onFileChange"
-            />
+
             <!-- <p @click="custom()">手動入力で授業を作成</p> -->
           </section>
           <!-- → その他オプション -->
-
-          <section class="register-btn" @click="asyncNumber()">
-            時間割に追加
-          </section>
+          <section class="save-btn" @click="asyncNumber()">時間割に追加</section>
         </article>
       </nav>
     </transition>
@@ -249,153 +238,139 @@ export default class Index extends Vue {
   left: 50%;
   transform: translateX(-50%) translateY(-50%);
   width: 92vw;
+  max-width: 70vh;
   height: 80vh;
-  background: #fff;
+  background: #ffffff;
   box-shadow: 1vmin 1vmin 3vmin rgba(0, 0, 0, 0.349);
   border-radius: 1vh;
   z-index: 6;
+  padding: 5vh;
+  box-sizing: border-box;
 }
 
 //++++++++++++++++++// 以下ダイアログの内容（中身） //+++++++++++++++++//
 article {
   position: relative;
-  margin: 4vmax;
-  height: calc(80vh - 10vh);
 }
 
 /* ボタン・アイコン */
 .close-btn {
   position: absolute;
-  top: -1.5vh;
-  right: -1.5vh;
+  top: -2.2vh;
+  right: -2.1vh;
   font-size: 4vh;
-  transition: all 0.15s;
   color: #717171;
 }
-.register-btn {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  margin-top: auto;
-  width: 100%;
-  font-size: 2.3vh;
-  height: 6vh;
-  line-height: 6vh;
-  background: #00c0c0;
-  border-radius: 1vh;
-  bottom: 0;
-  color: #fff;
-  text-align: center;
-  &:active {
-    transition: all 0.2s;
-    transform: translateX(-50%) scale(1.05);
-    background-color: #05dbdb;
-  }
-}
-@media screen and (min-width: 1300px) {
-  .register-btn {
-    max-width: 1000px;
-  }
+.icon {
+  display: inline-flex;
+  vertical-align: middle;
+  padding-bottom: 0.4vh;
 }
 
 /* 授業の追加 */
 h1 {
-  position: absolute;
-  top: -0.8vh;
   font-size: 2.9vh;
   color: #00c0c0;
   font-weight: 500;
-}
-.content {
-  position: absolute;
-  top: 4.5vh;
-  font-size: 2vh;
-  color: #555;
-  margin-left: 0.5vh;
-}
-.others {
-  position: absolute;
-  bottom: 7.5vh;
-  border-top: 1px solid #adadad;
-  width: 100%;
-}
-.others p {
-  font-size: 2vh;
-  color: #adadad;
-  margin-left: 0.5vh;
-  line-height: 100%;
-}
-.others input {
-  margin-left: auto;
-  margin-right: 0;
-  color: #adadad;
-  font-size: 1.8vh;
+  margin: 0 0 1.5vh;
 }
 
 /* 検索フォーム */
 .search-form {
-  position: absolute;
-  width: 98%;
-  height: 4.5vh;
-  top: 12vh;
-  margin: 0;
-}
-.form {
-  height: 100%;
-  width: 97%;
-  background-color: #fff;
-  border: 0.2vh solid #adadad;
-  color: #4a5568;
-  border-radius: 3vh;
   position: relative;
+  width: 100%;
+  height: 4.5vh;
   margin: 0;
   padding: 0;
-  padding-left: 3%;
-  font-size: 16px;
-}
-.search-btn {
-  position: absolute;
-  top: 0;
-  right: -0.4vh;
-  margin: 0;
-  padding: 0;
-  height: 4.8vh;
-  width: 4.8vh;
-  border-radius: 50% 50%;
-  background-color: #00c0c0;
-  color: #fff;
-  font-size: 3.5vh;
-  text-align: center;
-  line-height: 4.8vh;
-  &:active {
-    transition: all 0.2s;
-    transform: scale(1.1);
-    background-color: #05dbdb;
+  .form {
+    height: 100%;
+    width: 100%;
+    background-color: #fff;
+    border: 0.2vh solid #adadad;
+    color: #4a5568;
+    border-radius: 3vh;
+    position: relative;
+    margin: 0;
+    padding: 0;
+    padding-left: 3%;
+    font-size: 16px;
+    box-sizing: border-box;
   }
-}
-
-.form:focus {
-  border-color: #558afa;
-  outline: 0;
-  background-color: #fff;
+  .search-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 0;
+    padding: 0;
+    height: 4.5vh;
+    width: 4.5vh;
+    border-radius: 50% 50%;
+    background-color: #00c0c0;
+    color: #fff;
+    font-size: 3.5vh;
+    text-align: center;
+    line-height: 4.8vh;
+    &:active {
+      transition: all 0.2s;
+      transform: scale(1.1);
+      background-color: #05dbdb;
+    }
+  }
 }
 
 /** 検索結果 */
 .result-list {
-  position: absolute;
   width: 100%;
-  height: 30.5vh;
-  top: 17.9vh;
-  margin: 0;
+  height: 35vh;
+  margin: 1.5vh 0;
   padding: 1vw 0.5vw;
   overflow-y: scroll;
   scrollbar-color: rebeccapurple green;
   scrollbar-width: thin;
   font-size: 2vh;
   line-height: 150%;
+  box-sizing: border-box;
 }
 .result-list div {
   padding: 2vw;
+}
+
+//++++++++++++++++++++++++// 検索以外の追加方法 //++++++++++++++++++++++++//
+.others {
+  border-top: 1px solid #adadad;
+  width: 100%;
+}
+.content {
+  font-size: 2vh;
+  color: #9a9a9a;
+  margin-left: 0.5vh;
+  span {
+    font-size: 3.4vh;
+  }
+}
+.add-csv {
+  margin-top: 1vh;
+  color: #adadad;
+  font-size: 1.8vh;
+}
+
+//++++++++++++++++++++++++// 保存ボタン //++++++++++++++++++++++++//
+.save-btn {
+  display: block;
+  margin: 0 auto;
+  color: #fff;
+  width: 100%;
+  height: 6vh;
+  font-size: 2.3vh;
+  line-height: 6vh;
+  background: #00c0c0;
+  border-radius: 1vh;
+  text-align: center;
+  &:active {
+    transition: all 0.2s;
+    transform: scale(1.05);
+    background-color: #05dbdb;
+  }
 }
 
 //++++++++++++++++++++++++// 後ろ //++++++++++++++++++++++++//
@@ -407,13 +382,5 @@ h1 {
   top: 0px;
   background: rgba(100, 100, 100, 0.5);
   z-index: 5;
-}
-.twins-btn {
-  position: absolute;
-  top: 7.4vh;
-  margin-left: 0.5vh;
-  font-size: 1.8vh;
-  font-weight: 400;
-  color: #8c6cff;
 }
 </style>

--- a/src/components/def-dialog-add.vue
+++ b/src/components/def-dialog-add.vue
@@ -122,8 +122,6 @@ export default class Index extends Vue {
     this.$store.commit('visible/chAdd', { display: false });
   }
   twins() {
-    console.log(this.isMobile);
-
     if (this.isMobile) {
       twinsToTwinteAlert();
     } else {

--- a/src/components/def-dialog-detail.vue
+++ b/src/components/def-dialog-detail.vue
@@ -6,7 +6,9 @@
       <nav class="main" v-show="dialog">
         <article v-if="table">
           <!-- 教科名 -->
-          <div class="svg-button material-icons close-btn" @click="chDetail()">close</div>
+          <div class="svg-button material-icons close-btn" @click="chDetail()">
+            close
+          </div>
           <h1>
             <div class="sbj-name">{{ table.lecture_name }}</div>
 
@@ -55,11 +57,17 @@
               :class="{ attend: n === 1, absent: n === 2, late: n === 3 }"
               style="width: 30%"
             >
-              <span class="counter-name">{{ atmnb[n - 1] }} {{ atmnbCount[n - 1] }}回</span>
+              <span class="counter-name"
+                >{{ atmnb[n - 1] }} {{ atmnbCount[n - 1] }}回</span
+              >
               <!-- <+|-> -->
               <div class="counter">
-                <span @click="counter(atmnb[n - 1], +1)" class="counter-left">+</span>
-                <span @click="counter(atmnb[n - 1], -1)" class="counter-right">&#8211;</span>
+                <span @click="counter(atmnb[n - 1], +1)" class="counter-left"
+                  >+</span
+                >
+                <span @click="counter(atmnb[n - 1], -1)" class="counter-right"
+                  >&#8211;</span
+                >
               </div>
             </div>
           </section>

--- a/src/components/def-dialog-detail.vue
+++ b/src/components/def-dialog-detail.vue
@@ -262,7 +262,7 @@ export default class Index extends Vue {
   box-shadow: 1vmin 1vmin 3vmin rgba(0, 0, 0, 0.349);
   border-radius: 1vh;
   z-index: 6;
-  padding: 6vh;
+  padding: 5vh;
   box-sizing: border-box;
 }
 
@@ -346,7 +346,7 @@ h2 {
 /* メモ */
 .memo {
   width: 100%;
-  height: 12.5vh;
+  height: 14vh;
   border: 0.2vh solid #dddddd;
   border-radius: 0.5rem;
   margin: 0;
@@ -430,14 +430,14 @@ h2 {
   justify-content: space-between;
 }
 .delete-btn {
-  font-size: 2vh;
+  font-size: 2.1vh;
   color: rgb(255, 98, 98);
   i {
     font-size: 3vh;
   }
 }
 .edit-btn {
-  font-size: 2vh;
+  font-size: 2.1vh;
   color: rgb(102, 120, 223);
   i {
     font-size: 3vh;

--- a/src/components/def-dialog-detail.vue
+++ b/src/components/def-dialog-detail.vue
@@ -6,9 +6,7 @@
       <nav class="main" v-show="dialog">
         <article v-if="table">
           <!-- 教科名 -->
-          <div class="svg-button material-icons close-btn" @click="chDetail()">
-            close
-          </div>
+          <div class="svg-button material-icons close-btn" @click="chDetail()">close</div>
           <h1>
             <div class="sbj-name">{{ table.lecture_name }}</div>
 
@@ -17,28 +15,24 @@
 
           <!-- 科目詳細 -->
           <h2>
-            <span class="material-icons icon">info</span>科目詳細
+            <i class="material-icons icon">info</i>科目詳細
             <span class="syllabus-btn" @click="syllabus()">
               シラバス
-              <span class="material-icons syllabus-chevron">chevron_right</span>
+              <i class="material-icons icon">chevron_right</i>
             </span>
           </h2>
           <section class="sbj-detail-wrapper">
-            <p class="h3">
+            <p class="subject-item">
               担当教員
-              <span class="sbj-detail">{{ table.instructor }}</span>
+              <span>{{ table.instructor }}</span>
             </p>
-            <p class="h3">
+            <p class="subject-item">
               開講時限
-              <span class="sbj-detail"
-                >{{ table.module }} {{ table.day }}{{ table.period }}</span
-              >
+              <span>{{ table.module }} {{ table.day }}{{ table.period }}</span>
             </p>
-            <p class="h3">
+            <p class="subject-item">
               授業教室
-              <span v-if="!editableLecture" class="sbj-detail">
-                {{ table.room }}
-              </span>
+              <span v-if="!editableLecture">{{ table.room }}</span>
 
               <input v-else class="sbj-detail" v-model="editableLecture.room" />
               <!-- → 教室変更 -->
@@ -46,11 +40,11 @@
           </section>
 
           <!-- メモ -->
-          <h2 class="h2-2">
-            <span class="material-icons icon">create</span>メモ
+          <h2>
+            <i class="material-icons icon">create</i>メモ
             <span class="syllabus-btn" @click="attend()">
               出席
-              <span class="material-icons syllabus-chevron">chevron_right</span>
+              <i class="material-icons icon">chevron_right</i>
             </span>
           </h2>
           <textarea class="memo" type="text" v-model="localMemo"></textarea>
@@ -61,27 +55,23 @@
               :class="{ attend: n === 1, absent: n === 2, late: n === 3 }"
               style="width: 30%"
             >
-              <span class="counter-name"
-                >{{ atmnb[n - 1] }} {{ atmnbCount[n - 1] }}回</span
-              >
+              <span class="counter-name">{{ atmnb[n - 1] }} {{ atmnbCount[n - 1] }}回</span>
               <!-- <+|-> -->
               <div class="counter">
-                <span @click="counter(atmnb[n - 1], +1)" class="counter-left"
-                  >+</span
-                >
-                <span @click="counter(atmnb[n - 1], -1)" class="counter-right"
-                  >&#8211;</span
-                >
+                <span @click="counter(atmnb[n - 1], +1)" class="counter-left">+</span>
+                <span @click="counter(atmnb[n - 1], -1)" class="counter-right">&#8211;</span>
               </div>
             </div>
           </section>
           <div @click="save()" class="save-btn">変更を保存</div>
-          <p @click="deleteItem()" class="delete-btn">
-            <span class="material-icons delete-icon">delete</span>この科目を削除
-          </p>
-          <p @click="edit()" class="edit-btn">
-            <span class="material-icons delete-icon">edit</span>教室情報を編集
-          </p>
+          <div class="flex">
+            <p @click="deleteItem()" class="delete-btn">
+              <i class="material-icons icon">delete</i>この科目を削除
+            </p>
+            <p @click="edit()" class="edit-btn">
+              <i class="material-icons icon">edit</i>教室情報を編集
+            </p>
+          </div>
         </article>
       </nav>
     </transition>
@@ -266,25 +256,22 @@ export default class Index extends Vue {
   left: 50%;
   transform: translateX(-50%) translateY(-50%);
   width: 92vw;
+  max-width: 70vh;
   height: 80vh;
   background: #ffffff;
   box-shadow: 1vmin 1vmin 3vmin rgba(0, 0, 0, 0.349);
   border-radius: 1vh;
   z-index: 6;
+  padding: 6vh;
+  box-sizing: border-box;
 }
 
 //++++++++++++++++++// 以下ダイアログの内容（中身） //+++++++++++++++++//
 article {
   position: relative;
-  margin: 4vmax;
-  height: calc(80vh - 10vh);
 }
 
 /* ボタン・アイコン */
-.icon {
-  font-size: 2.9vh;
-  margin-bottom: 0;
-}
 .close-btn {
   position: absolute;
   top: -2.2vh;
@@ -292,145 +279,87 @@ article {
   font-size: 4vh;
   color: #717171;
 }
-.save-btn {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 100%;
-  font-size: 2.3vh;
-  height: 6vh;
-  line-height: 6vh;
-  background: #00c0c0;
-  border-radius: 1vh;
-  bottom: 3.1vh;
-  color: #fff;
-  text-align: center;
-  &:active {
-    transition: all 0.2s;
-    transform: translateX(-50%) scale(1.05);
-    background-color: #05dbdb;
-  }
-}
-.delete-btn {
-  position: absolute;
-  bottom: -1.7vh;
-  font-size: 2vh;
-  color: rgb(255, 98, 98);
-  margin: 0;
-}
-.edit-btn {
-  position: absolute;
-  bottom: -1.7vh;
-  right: 0;
-  font-size: 2vh;
-  color: rgb(102, 120, 223);
-  margin: 0;
-}
 .icon {
-  font-size: 2.7vh;
-  position: relative;
-  bottom: -0.4vh;
-  margin-right: 0.4vh;
-}
-.syllabus-chevron {
-  position: relative;
-  bottom: -0.9vh;
-}
-.delete-icon {
-  position: relative;
-  font-size: 3.2vh;
+  display: inline-flex;
   vertical-align: middle;
-  top: -0.2vh;
+  padding-bottom: 0.4vh;
 }
 
 /* 科目の情報 */
 h1 {
-  position: absolute;
-  top: -0.6vh;
-  padding-left: 1.2vh;
-  width: calc(100% - 1.5vh - 2vh);
   border-left: 0.8vh solid #00c0c0;
+  color: #555555;
+  font-size: 2.9vh;
+  line-height: 4.5vh;
+  font-weight: 500;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
   height: 8vh;
-}
-.sbj-name {
-  color: #555555;
-  font-size: 2.7vh;
-  font-weight: 500;
-  line-height: 4.5vh;
+  padding-left: 0.9vh;
   margin: 0;
-}
-.sbj-number {
-  color: #c4c4c4;
-  font-size: 1.8vh;
-  font-weight: 400;
-  line-height: 3.5vh;
-  margin: 0;
+  .sbj-number {
+    color: #c4c4c4;
+    font-size: 1.8vh;
+    font-weight: 400;
+    line-height: 3.5vh;
+    margin: 0;
+  }
 }
 h2 {
-  position: absolute;
-  top: 10.3vh;
   width: 100%;
   color: #00c0c0;
   border-bottom: 0.2vh solid #00c0c0;
-  padding-bottom: 0.1vh;
   font-weight: 500;
-  font-size: 2.2vh;
+  font-size: 2.3vh;
+  i {
+    font-size: 2.9vh;
+  }
+  .syllabus-btn {
+    line-height: 3vh;
+    position: absolute;
+    right: 0;
+    font-size: 1.9vh;
+    font-weight: 400;
+    color: #c4c4c4;
+    i {
+      font-size: 3vh;
+    }
+  }
 }
-.syllabus-btn {
-  position: absolute;
-  right: 0;
-  font-size: 1.9vh;
-  font-weight: 400;
-  color: #c4c4c4;
-  bottom: 2px;
-}
+
 .sbj-detail-wrapper {
-  position: absolute;
-  top: 15.7vh;
-  font-size: 2vh;
-  left: 4%;
-  width: 96%;
+  padding: 0 2.5vmin;
+  font-size: 2.1vh;
+  line-height: 2.1vh;
+  margin-bottom: 3vh;
 }
-.h3 {
+.subject-item {
   color: #555555;
   font-weight: 500;
-}
-.sbj-detail {
-  padding-left: 5%;
-  font-weight: 400;
+  span {
+    padding-left: 5%;
+    font-weight: 400;
+  }
 }
 
 /* メモ */
-.h2-2 {
-  position: absolute;
-  top: 29.6vh;
-}
 .memo {
-  position: absolute;
-  bottom: 21vh;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 93%;
+  width: 100%;
   height: 12.5vh;
   border: 0.2vh solid #dddddd;
+  border-radius: 0.5rem;
+  margin: 0;
   box-sizing: border-box;
-  border-radius: 8px;
 }
 
 /* 出欠 */
 .counters-wrapper {
   text-align: center;
-  position: absolute;
-  bottom: 11.3vh;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 94%;
   grid-template-columns: repeat(3, 1fr);
   display: flex;
-  justify-content: space-between;
+  justify-content: space-around;
+  margin-bottom: 2vh;
 }
 .counter-name {
   line-height: 4.4vh;
@@ -452,7 +381,7 @@ h2 {
 }
 .counter-left {
   color: #00c0c0;
-  font-size: 5vh;
+  font-size: 4.4vh;
   line-height: 4.3vh;
   width: 50%;
   border: 0.2vh solid #00c0c0;
@@ -462,7 +391,7 @@ h2 {
 }
 .counter-right {
   color: #00c0c0;
-  font-size: 4.9vh;
+  font-size: 4.3vh;
   line-height: 3.4vh;
   width: 50%;
   border: 0.2vh solid #00c0c0;
@@ -475,6 +404,44 @@ h2 {
 .counter-right:active {
   background-color: #00c0c0;
   color: white;
+}
+
+//++++++++++++++++++++++++// 保存・編集・削除ボタン //++++++++++++++++++++++++//
+.save-btn {
+  display: block;
+  margin: 0 auto;
+  color: #fff;
+  width: 100%;
+  height: 6vh;
+  font-size: 2.3vh;
+  line-height: 6vh;
+  background: #00c0c0;
+  border-radius: 1vh;
+  text-align: center;
+  &:active {
+    transition: all 0.2s;
+    transform: translateX(-50%) scale(1.05);
+    background-color: #05dbdb;
+  }
+}
+
+.flex {
+  display: flex;
+  justify-content: space-between;
+}
+.delete-btn {
+  font-size: 2vh;
+  color: rgb(255, 98, 98);
+  i {
+    font-size: 3vh;
+  }
+}
+.edit-btn {
+  font-size: 2vh;
+  color: rgb(102, 120, 223);
+  i {
+    font-size: 3vh;
+  }
 }
 
 //++++++++++++++++++++++++// 後ろ //++++++++++++++++++++++++//

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -90,6 +90,11 @@ export default class Index extends Vue {
       }
     }
     // → lectureパラメータがあればそのダイアログを表示
+
+    document.documentElement.style.setProperty(
+      '--outer-height',
+      `${window.outerHeight}px`
+    );
   }
 }
 </script>

--- a/src/pages/display-settings.vue
+++ b/src/pages/display-settings.vue
@@ -17,8 +17,8 @@
                 class="setting-checkbox"
               />
               <label class="display-check" for="lecture_number">
-                <span></span>
-              </label>科目番号
+                <span></span> </label
+              >科目番号
             </li>
             <li>
               <input
@@ -30,8 +30,8 @@
                 class="setting-checkbox"
               />
               <label class="display-check" for="instructor">
-                <span></span>
-              </label>担当教員
+                <span></span> </label
+              >担当教員
             </li>
             <li>
               <input
@@ -42,9 +42,8 @@
                 id="room"
                 class="setting-checkbox"
               />
-              <label class="display-check" for="room">
-                <span></span>
-              </label>教室名
+              <label class="display-check" for="room"> <span></span> </label
+              >教室名
             </li>
           </ul>
         </section>

--- a/src/pages/display-settings.vue
+++ b/src/pages/display-settings.vue
@@ -176,7 +176,7 @@ h1 {
     margin: 0;
   }
   li {
-    font-size: 2.5vh;
+    font-size: 2.2vh;
     line-height: 2.3 * 2.7vh;
   }
 }
@@ -206,7 +206,7 @@ h3 {
 }
 
 .display-check {
-  margin-right: 3%;
+  margin-right: 4%;
   vertical-align: middle;
   display: inline-block;
   position: relative;

--- a/src/pages/display-settings.vue
+++ b/src/pages/display-settings.vue
@@ -16,9 +16,9 @@
                 id="lecture_number"
                 class="setting-checkbox"
               />
-              <label class="display-check" for="lecture_number"
-                ><span></span></label
-              >科目番号
+              <label class="display-check" for="lecture_number">
+                <span></span>
+              </label>科目番号
             </li>
             <li>
               <input
@@ -29,8 +29,9 @@
                 id="instructor"
                 class="setting-checkbox"
               />
-              <label class="display-check" for="instructor"><span></span></label
-              >担当教員
+              <label class="display-check" for="instructor">
+                <span></span>
+              </label>担当教員
             </li>
             <li>
               <input
@@ -41,8 +42,9 @@
                 id="room"
                 class="setting-checkbox"
               />
-              <label class="display-check" for="room"><span></span></label
-              >教室名
+              <label class="display-check" for="room">
+                <span></span>
+              </label>教室名
             </li>
           </ul>
         </section>
@@ -56,33 +58,36 @@
       <section class="fontsize-setting">
         <h3>文字の大きさ</h3>
         <div class="fontsizebtn-flex">
-          <label
-            ><input
+          <label>
+            <input
               @change="setSbj()"
               v-model="sbj.font_size"
               type="radio"
               value="small"
               class="setting-radio"
-            /><span class="fontsize-btn">小</span></label
-          >
-          <label
-            ><input
+            />
+            <span class="fontsize-btn">小</span>
+          </label>
+          <label>
+            <input
               @change="setSbj()"
               v-model="sbj.font_size"
               type="radio"
               value="medium"
               class="setting-radio"
-            /><span class="fontsize-btn">中</span></label
-          >
-          <label
-            ><input
+            />
+            <span class="fontsize-btn">中</span>
+          </label>
+          <label>
+            <input
               @change="setSbj()"
               v-model="sbj.font_size"
               type="radio"
               value="large"
               class="setting-radio"
-            /><span class="fontsize-btn">大</span></label
-          >
+            />
+            <span class="fontsize-btn">大</span>
+          </label>
         </div>
         <!-- <button @click="setSbj()">保存</button> -->
       </section>


### PR DESCRIPTION
## 概要/目的
科目追加と科目詳細のダイアログのデザイン・レイアウトを修正

## やったこと・変更内容
要素のレイアウトを絶対指定から相対指定に変更
横長の画面において要素が横に広がりすぎていたので、カードにmax-widthを設定
検索結果一覧のheightを高く
Twinsからインポートボタンの位置を変更
その他細余白、font-size等の細かい修正

## 確認したこと
- [x] done
- [ ] not

## 備考

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
出欠ボタンの横幅が広がりすぎないようになりました