### PR TITLE
fix 全削除ダイアログを出さないように

### DIFF
--- a/src/components/def-nav.vue
+++ b/src/components/def-nav.vue
@@ -95,6 +95,7 @@ export default class Index extends Vue {
           break;
         case 'func:twins':
           twinsToTwinteAlert();
+          break;
         case 'func:delete':
           if (await deleteAlert()) {
             deleteUserDataAll();


### PR DESCRIPTION
## 概要/目的
Twinsからインポートダイアログを押すと全削除ダイアログが出てしまう
## やったこと・変更内容
switch 内に `break` を追加した

## 確認したこと
ちゃんとTwinsからインポートダイアログが出るようになった
- [x] done
- [ ] not

## 備考
なし