### PR TITLE
safariでのレイアウト崩れ・フォントサイズを修正

### DIFF
--- a/src/assets/css/btn.scss
+++ b/src/assets/css/btn.scss
@@ -1,5 +1,6 @@
 // 保存ボタンのスタイル
 .save-btn {
+  position: relative;
   display: block;
   margin: 0 auto;
   color: #fff;

--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -17,7 +17,7 @@ html {
 }
 @media screen and (min-height: 1000px) {
   html {
-    font-size: 95%;
+    font-size: 85%;
   }
 }
 

--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -17,7 +17,7 @@ html {
 }
 @media screen and (min-height: 1000px) {
   html {
-    font-size: 85%;
+    font-size: 95%;
   }
 }
 

--- a/src/components/def-dialog-detail.vue
+++ b/src/components/def-dialog-detail.vue
@@ -352,8 +352,14 @@ h2 {
 
 /* 出欠 */
 .counters-wrapper {
-  display: flex;
-  justify-content: space-between;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -o-box;
+  display: box;
+  -moz-box-pack: justify;
+  -webkit-box-pack: justify;
+  -o-box-pack: justify;
+  -ms-box-pack: justify;
   text-align: center;
   grid-template-columns: repeat(3, 1fr);
   margin-bottom: 2vh;

--- a/src/components/def-dialog-detail.vue
+++ b/src/components/def-dialog-detail.vue
@@ -346,6 +346,8 @@ h2 {
   min-height: 10vh;
   border: 0.2vh solid #dddddd;
   border-radius: 0.5rem;
+  flex-basis: 20vh;
+  flex-shrink: 2;
   margin: 1vh 0;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## 概要/目的
safariでの科目詳細のレイアウト崩があったので修正

## やったこと・変更内容
出欠欄をflexからboxに
min-heiht:1000pxでのfont-sizeを85%から95%に

## 確認したこと

- [x] done
- [ ] not

## 備考

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
