### PR TITLE
change: 最新版シラバスを表示するように

### DIFF
--- a/src/components/def-dialog-detail.vue
+++ b/src/components/def-dialog-detail.vue
@@ -79,15 +79,15 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'nuxt-property-decorator';
-import * as Vuex from 'vuex';
-import { Period } from '../types';
-import { UserLectureEntity } from '../types/server';
-import { updateLecture } from '../store/api/timetables';
-import cloneDeep from 'lodash/cloneDeep';
-import Swal from 'sweetalert2';
-import { YEAR } from '../common/config';
-import { openUrl } from './utils/openUrl'; 
+import { Component, Vue } from 'nuxt-property-decorator'
+import * as Vuex from 'vuex'
+import { Period } from '../types'
+import { UserLectureEntity } from '../types/server'
+import { updateLecture } from '../store/api/timetables'
+import cloneDeep from 'lodash/cloneDeep'
+import Swal from 'sweetalert2'
+import { YEAR } from '../common/config'
+import { openUrl } from './utils/openUrl'
 
 @Component({
   components: {
@@ -119,10 +119,12 @@ export default class Index extends Vue {
   }
 
   syllabus() {
-    openUrl(`https://kdb.tsukuba.ac.jp/syllabi/${YEAR}/${this.table?.lecture_code}/jpn/#course-title`);
+    openUrl(
+      `https://kdb.tsukuba.ac.jp/syllabi/${YEAR}/${this.table?.lecture_code}/jpn/0/`
+    )
   }
   attend() {
-    openUrl('https://atmnb.tsukuba.ac.jp');
+    openUrl('https://atmnb.tsukuba.ac.jp')
   }
   edit() {
     if (this.editableLecture) {

--- a/src/components/utils/openUrl.ts
+++ b/src/components/utils/openUrl.ts
@@ -1,10 +1,10 @@
 export const openUrl = (url: string) => {
   const isMobile =
     /iP(hone|(o|a)d)/.test(navigator.userAgent) ||
-    /TwinteAppforAndroid/.test(navigator.userAgent);
+    /TwinteAppforAndroid/.test(navigator.userAgent)
   if (isMobile) {
-    location.href = url;
+    location.href = url
   } else {
-    window.open(url);
+    window.open(url)
   }
-};
+}

--- a/src/components/utils/swal.ts
+++ b/src/components/utils/swal.ts
@@ -33,8 +33,8 @@ const twinsToTwinteAlert = () => {
         title: '注意',
         html:
           'この機能は自己責任での利用となっております。この機能を利用して起きた損害等は一切Twin:teは責任を負いません。詳細は<a href="https://www.twinte.net/terms" target="_blank">利用規約</a>をご覧ください。',
-        type: 'warning'
-      }
+        type: 'warning',
+      },
     ])
     .then((result) => {
       if (result.value) {


### PR DESCRIPTION
## 概要/目的
シラバスのデフォルト表示を最新版のシラバスにしました。
## やったこと・変更内容
URLを
` https://kdb.tsukuba.ac.jp/syllabi/年度/授業番号/jpn/0/ ` 
に変更しました。
` #course-title ` は、公式版シラバスへのリンクに気づかない可能性があるので消去しました。
## 確認したこと
幾らかの授業で最新版シラバスが出ることを確認しましたが、出ない授業があるのか定かでないです。


<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
