### PR TITLE
Fix144/searchform fontsize

### DIFF
--- a/src/components/def-modal-add.vue
+++ b/src/components/def-modal-add.vue
@@ -325,7 +325,7 @@ article {
   }
   ::placeholder {
     color: #9a9a9a;
-    font-size: 1.2rem;
+    font-size: 14px;
     padding-top: 4px;
   }
   :focus {

--- a/src/components/def-modal-add.vue
+++ b/src/components/def-modal-add.vue
@@ -294,7 +294,7 @@ article {
     height: 100%;
     width: 100%;
     background-color: #fff;
-    font-size: 1.2rem;
+    font-size: 16px;
     color: #555555;
     box-sizing: border-box;
     border: 0.2vh solid #9a9a9a;


### PR DESCRIPTION
## 概要
iosにおいて、検索フォームへのフォーカス時にズームしないようにした

## やったこと・変更内容
- Fix #144 
検索フォームのfont-sizeを1.2remから16pxに変更

## 確認したこと

## 備考

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
