### PR TITLE
Layout grid

### DIFF
--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -12,6 +12,7 @@ html {
   height: 100%;
   font-size: 62.5%;
   color: $main-text-color;
+  box-sizing: border-box;
 }
 @media screen and (min-height: 1000px) {
   html {

--- a/src/components/app-table-header.vue
+++ b/src/components/app-table-header.vue
@@ -13,9 +13,9 @@
         >chevron_right</span
       >
     </div>
-    <div class="table-header__week">
+    <div class="table-header__wrap">
       <Day class="table-header__week-cal"></Day>
-      <section class="table-header__week-wrapper">
+      <section class="table-header__wrap--week">
         <div v-for="n in 5" :key="n">{{ week[n - 1] }}</div>
       </section>
     </div>
@@ -72,9 +72,12 @@ export default class Index extends Vue {
 <style lang="scss" scoped>
 @import '~/assets/css/variable.scss';
 
-$week-width: calc(100vw - 8vw - 13vw);
+$week-width: calc(100vw - 8vmin - 11vw);
 
 .table-header {
+  box-sizing: border-box;
+  height: 8.4vh;
+
   &__icon {
     display: block;
     width: 15vw;
@@ -95,22 +98,21 @@ $week-width: calc(100vw - 8vw - 13vw);
     left: 50%;
     transform: translateX(-50%);
   }
-  &__week {
+  &__wrap {
     position: relative;
     display: flex;
-    width: 87vw;
     height: 2.5vh;
     font-style: normal;
     font-weight: 400;
     font-size: 2vh;
     color: #9a9a9a;
 
-    &-wrapper {
+    &--week {
       position: absolute;
       display: flex;
       width: $week-width;
       justify-content: space-around;
-      left: calc(13vw + 4vw);
+      left: calc(11vw + 4vmin);
       top: 0.6vh;
     }
   }

--- a/src/components/app-timetable.vue
+++ b/src/components/app-timetable.vue
@@ -25,12 +25,9 @@
 
       <!-- 授業 -->
       <div class="timetable-panel__subjects-wrap">
-        <section v-for="subjectIndex in 30" :key="subjectIndex">
+        <section v-for="subject in subjects(30)" :key="subject">
           <!-- 日: 0, 月: 1, 火: 2, 水: 3, 木: 4, 金: 5, 土: 6 -->
-          <Subject
-            :day="subject(subjectIndex).day"
-            :period="subject(subjectIndex).period"
-          />
+          <Subject :day="subject.day" :period="subject.period" />
         </section>
       </div>
     </content>
@@ -56,13 +53,15 @@ export default class Index extends Vue {
     ['15:15', '16:30'],
     ['16:45', '18:00'],
   ]
-  subject(num: number) {
-    const day = Math.floor(num / 6 + 1)
-    const period = num % 6
-    return {
-      day,
-      period,
-    }
+  subjects(num: number) {
+    return [...Array(num).keys()].map((i) => {
+      const day = Math.floor(i / 6 + 1)
+      const period = (i % 6) + 1
+      return {
+        day,
+        period,
+      }
+    })
   }
   get visible() {
     return this.$store.getters['visible/table'].display

--- a/src/components/app-timetable.vue
+++ b/src/components/app-timetable.vue
@@ -2,37 +2,37 @@
   <!--
    * 時間割カード
    *
-   * height 65vh x width 69vw
    * period: 時限, day: 曜日
    *
    * 授業内容は ./ui-subject.vue を参照
   -->
   <transition :name="moveDirection === 'left' ? 'slide-l' : 'slide-r'">
-    <content class="row" v-show="visible">
+    <content class="timetable-panel" v-show="visible">
       <!-- 時限 -->
-      <section class="column">
-        <div
-          class="time"
+      <div class="timetable-panel__times-wrap">
+        <section
+          class="timetable-panel__times"
           v-for="i in 6"
           :key="i"
           :style="{ background: i % 2 === 0 ? '#F3F3F3' : '#F8F8F8' }"
         >
           {{ i }}
           <p>{{ timeTable[i - 1][0] }}</p>
-          <p class="tilde">~</p>
+          <p class="timetable-panel__times--tilde">~</p>
           <p>{{ timeTable[i - 1][1] }}</p>
-        </div>
-      </section>
+        </section>
+      </div>
 
       <!-- 授業 -->
-      <section class="row">
-        <!-- 日: 0, 月: 1, 火: 2, 水: 3, 木: 4, 金: 5, 土: 6 -->
-        <div v-for="day in 5" :key="day" class="column">
-          <div v-for="period in 6" :key="period">
-            <Subject :day="day" :period="period" />
-          </div>
-        </div>
-      </section>
+      <div class="timetable-panel__subjects-wrap">
+        <section v-for="subjectIndex in 30" :key="subjectIndex">
+          <!-- 日: 0, 月: 1, 火: 2, 水: 3, 木: 4, 金: 5, 土: 6 -->
+          <Subject
+            :day="subject(subjectIndex).day"
+            :period="subject(subjectIndex).period"
+          />
+        </section>
+      </div>
     </content>
   </transition>
 </template>
@@ -56,6 +56,14 @@ export default class Index extends Vue {
     ['15:15', '16:30'],
     ['16:45', '18:00'],
   ]
+  subject(num: number) {
+    const day = Math.floor(num / 6 + 1)
+    const period = num % 6
+    return {
+      day,
+      period,
+    }
+  }
   get visible() {
     return this.$store.getters['visible/table'].display
   }
@@ -67,50 +75,48 @@ export default class Index extends Vue {
 <style lang="scss" scoped>
 @import '~/assets/css/variable.scss';
 
-$height: calc((100vh - 16.5vh - 6vmin - 12vmin) / 6);
-$width: calc((100vw - 8vw - 11vw - 12vw) / 5);
-
-//++++++++++++++++++++++++// 時間割表の枠 //++++++++++++++++++++++++//
-content {
+.timetable-panel {
+  box-sizing: border-box;
+  height: 82vh;
   position: relative;
-  margin: 2vmin 2vw;
-  padding: 2vmin 2vw;
+  margin: 0 2vmin 2vmin;
+  padding: 2vmin;
   box-shadow: $large-shadow;
-  border-radius: 10px;
-}
-
-//+++++++++++++++++++// 以下時間割の内容（中身） //++++++++++++++++++//
-
-/* 縦横の整列 */
-.row {
+  border-radius: 0.5rem;
   display: flex;
-  flex-direction: row;
-}
-.column {
-  display: flex;
-  flex-direction: column;
-}
 
-/* 時限 */
-.time {
-  width: 11vw;
-  height: $height;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 1.9vh;
-  line-height: 3vh;
-  text-align: center;
-  color: #9a9a9a;
-  padding: 1vmin 1vw;
-}
+  &__times-wrap {
+    display: flex;
+    flex-direction: column;
+  }
 
-.column p {
-  font-size: 1.65vh;
-  line-height: 1vh;
-  font-weight: 400;
-}
-.tilde {
-  transform: rotate(90deg);
+  &__times {
+    height: 100%;
+    width: 11vw;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 1.9vh;
+    line-height: 3vh;
+    text-align: center;
+    color: #9a9a9a;
+    p {
+      font-size: 1.65vh;
+      line-height: 1vh;
+      font-weight: 400;
+    }
+    &--tilde {
+      transform: rotate(90deg);
+    }
+  }
+
+  &__subjects-wrap {
+    display: block;
+    width: 100%;
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-rows: repeat(6, calc(calc(82vh - 4vmin) / 6));
+    grid-template-columns: repeat(5, 1fr);
+  }
 }
 
 /* animation */

--- a/src/components/app-week-timetable.vue
+++ b/src/components/app-week-timetable.vue
@@ -2,27 +2,26 @@
   <!--
    * 時間割カード
    *
-   * height 65vh x width 69vw
    * period: 時限, day: 曜日
    *
    * 授業内容は ./ui-subject.vue を参照
   -->
   <transition :name="moveDirection === 'left' ? 'slide-l' : 'slide-r'">
-    <content class="row" v-show="visible">
+    <content class="timetable-panel" v-show="visible">
       <!-- 時限 -->
-      <section class="column">
-        <div
-          class="time"
+      <div class="timetable-panel__times-wrap">
+        <section
+          class="timetable-panel__times"
           v-for="i in 6"
           :key="i"
           :style="{ background: i % 2 === 0 ? '#F3F3F3' : '#F8F8F8' }"
         >
           {{ i }}
           <p>{{ timeTable[i - 1][0] }}</p>
-          <p class="tilde">~</p>
+          <p class="timetable-panel__times--tilde">~</p>
           <p>{{ timeTable[i - 1][1] }}</p>
-        </div>
-      </section>
+        </section>
+      </div>
 
       <!-- 授業 -->
       <section class="row">
@@ -105,51 +104,45 @@ export default class Index extends Vue {
 </script>
 <style lang="scss" scoped>
 @import '~/assets/css/variable.scss';
-
-$height: calc((100vh - 16.5vh - 6vmin - 12vmin) / 6);
-$width: calc((100vw - 8vw - 11vw - 12vw) / 5);
-
-//++++++++++++++++++++++++// 時間割表の枠 //++++++++++++++++++++++++//
-content {
+.timetable-panel {
   position: relative;
-  margin: 2vmin 2vw;
-  padding: 2vmin 2vw;
+  margin: 2vmin;
+  padding: 2vmin;
   box-shadow: $large-shadow;
-  border-radius: 10px;
-}
-
-//+++++++++++++++++++// 以下時間割の内容（中身） //++++++++++++++++++//
-
-/* 縦横の整列 */
-.row {
+  border-radius: 0.5rem;
   display: flex;
-  flex-direction: row;
-}
-.column {
-  display: flex;
-  flex-direction: column;
-}
 
-/* 時限 */
-.time {
-  width: 11vw;
-  height: $height;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 1.9vh;
-  line-height: 3vh;
-  text-align: center;
-  color: #9a9a9a;
-  padding: 1vmin 1vw;
-}
+  &__times-wrap {
+    display: flex;
+    flex-direction: column;
+  }
 
-.column p {
-  font-size: 1.65vh;
-  line-height: 1vh;
-  font-weight: 400;
-}
-.tilde {
-  transform: rotate(90deg);
+  &__times {
+    width: 11vw;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 1.9vh;
+    line-height: 3vh;
+    text-align: center;
+    color: #9a9a9a;
+    padding: 1vmin 1vw;
+    p {
+      font-size: 1.65vh;
+      line-height: 1vh;
+      font-weight: 400;
+    }
+    &--tilde {
+      transform: rotate(90deg);
+    }
+  }
+
+  &__subjects-wrap {
+    width: 100%;
+    display: grid;
+    grid-auto-flow: column;
+    grid-template-rows: repeat(6, 1fr);
+    grid-template-columns: repeat(5, 1fr);
+  }
 }
 
 /* animation */

--- a/src/components/app-week-timetable.vue
+++ b/src/components/app-week-timetable.vue
@@ -24,16 +24,14 @@
       </div>
 
       <!-- 授業 -->
-      <section class="row">
+      <section class="timetable-panel__subjects-wrap">
         <!-- 日: 0, 月: 1, 火: 2, 水: 3, 木: 4, 金: 5, 土: 6 -->
-        <div v-for="date in weekCalender" :key="date.date" class="column">
-          <div v-for="period in 6" :key="period">
-            <Subject
-              :day="date.day"
-              :period="period"
-              :moduleProp="date.module"
-            />
-          </div>
+        <div v-for="(date, i) in weekCalender" :key="i">
+          <Subject
+            :day="date.day"
+            :period="date.period"
+            :moduleProp="date.module"
+          />
         </div>
       </section>
     </content>
@@ -81,17 +79,24 @@ export default class Index extends Vue {
     //   date: "2020-06-14"
     //   day: 0 ← 日曜日の時間割
     //   module: "春B"
+    //   period: 3 ← 3限
     // }
-    this.weekCalender = (await Promise.all(weeks.map(getSchoolCalender)))
+    // fixme
+    const calender = await Promise.all(weeks.map(getSchoolCalender))
+    this.weekCalender = calender
       .map(({ data: d }, i) => ({
         module: d.module,
         day: d.substituteDay ? this.week2num(d.substituteDay.change_to) : i,
         date: weeks[i],
       }))
       .slice(1, 6)
-
-    // 今週の曜日を出力
-    console.log(this.weekCalender)
+      .reduce(
+        (sum: any[], cal) => [
+          ...sum,
+          ...[...Array(6).keys()].map((i) => ({ ...cal, period: i + 1 })),
+        ],
+        []
+      )
   }
 
   get visible() {
@@ -104,6 +109,7 @@ export default class Index extends Vue {
 </script>
 <style lang="scss" scoped>
 @import '~/assets/css/variable.scss';
+
 .timetable-panel {
   position: relative;
   margin: 2vmin;

--- a/src/components/ui-subject.vue
+++ b/src/components/ui-subject.vue
@@ -1,22 +1,22 @@
 <template>
-  <section @click="popUp()">
-    <div class="subject" v-if="!table"></div>
-    <!-- → 授業が入っていない -->
+  <div class="subject" @click="popUp()" v-if="!table"></div>
+  <!-- → 授業が入っていない -->
 
-    <div class="subject" v-else :style="setSubjectStyle()">
-      <div v-if="display.lecture_code" class="subject__lectureId">
-        {{ table.lecture_code }}
-      </div>
-      <div v-if="display.lecture_name" class="subject__name">
-        {{ table.lecture_name }}
-      </div>
-      <div v-if="display.instructor" class="subject__instructor">
-        {{ table.instructor }}
-      </div>
-      <div v-if="display.room" class="subject__room">{{ table.room }}</div>
+  <div class="subject" @click="popUp()" v-else :style="setSubjectStyle()">
+    <div v-if="display.lecture_code" class="subject--lectureId">
+      {{ table.lecture_code }}
     </div>
-    <!-- → 授業が入っている -->
-  </section>
+    <div v-if="display.lecture_name" class="subject--name">
+      {{ table.lecture_name }}
+    </div>
+    <div v-if="display.instructor" class="subject--instructor">
+      {{ table.instructor }}
+    </div>
+    <div v-if="display.room" class="subject--room">
+      {{ table.room }}
+    </div>
+  </div>
+  <!-- → 授業が入っている -->
 </template>
 
 <script lang="ts">
@@ -149,37 +149,33 @@ export default class Index extends Vue {
 <style lang="scss" scoped>
 @import '~/assets/css/variable.scss';
 
-/** FIXME gridにしてwidthとheightを消して! */
-$height: calc((100vh - 16.5vh - 6vmin - 12vmin) / 6);
-$width: calc((100vw - 8vw - 11vw - 12vw) / 5);
-
 /* 科目 */
 .subject {
-  width: $width;
-  height: $height;
-  padding: 1vmin 1vw;
+  height: 100%;
+  box-sizing: border-box;
   word-break: break-all;
   font-style: normal;
   font-weight: 500;
   overflow: hidden;
+  padding: 1.1vmin;
   &:active {
     transition: all 0.3s;
     filter: brightness(150%);
   }
 
-  &__lectureId {
+  &--lectureId {
     color: $main-text-color;
     font-weight: 400;
   }
-  &__name {
+  &--name {
     color: $emphasis-text-color;
     font-weight: 600;
   }
-  &__instructor {
+  &--instructor {
     color: $main-text-color;
     font-weight: 400;
   }
-  &__room {
+  &--room {
     color: $main-text-color;
     font-weight: 400;
   }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -12,7 +12,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
 @Component({
   components: {
     TableHeader: () => import('~/components/app-table-header.vue'),
-    Table: () => import('~/components/app-table-contents.vue'),
+    Table: () => import('~/components/app-timetable.vue'),
     ModalDetail: () => import('~/components/app-modal-detail.vue'),
   },
 })

--- a/src/pages/week.vue
+++ b/src/pages/week.vue
@@ -10,7 +10,7 @@ import { Component, Vue } from 'nuxt-property-decorator'
 
 @Component({
   components: {
-    Table: () => import('~/components/app-week-table-contents.vue'),
+    Table: () => import('~/components/app-week-timetable.vue'),
     ModalDetail: () => import('~/components/app-modal-detail.vue'),
   },
 })


### PR DESCRIPTION
## 概要
時間割表のsubjectの並びをgrid指定にした。

## やったこと・変更内容
- Fix #165 

## 確認したこと
- [x] Safari,Chromeでレイアウトが崩れないこと。

## 備考
土曜込みの時間割の方は未修正(@HikaruEgashira がやってくれるらしい)。
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
