### PR TITLE
お知らせの余白つめたりリンクの文字色を指定したりした

### DIFF
--- a/src/components/def-modal-information.vue
+++ b/src/components/def-modal-information.vue
@@ -1,28 +1,30 @@
 <template>
   <Dialog class="info" :show="show" @close="close()">
-    <h1 class="info__title">Twin:teからの新着お知らせ</h1>
-    <div class="info__body">
-      <section class="info__post" v-for="info in information" :key="info.id">
-        <div class="info__date">{{ info.date }}</div>
-        <h2 class="info__topic-title">{{ info.title }}</h2>
-        <div class="info__content" v-html="info.content" />
-        <hr class="info__divider" v-if="information.slice(-1)[0] !== info" />
-      </section>
-    </div>
-    <Button class="info__button" @button-click="close()">OK</Button>
+    <article class="info__layout">
+      <h1 class="info__title">Twin:teからの新着お知らせ</h1>
+      <div class="info__body">
+        <section class="info__post" v-for="info in information" :key="info.id">
+          <div class="info__date">{{ info.date }}</div>
+          <h2 class="info__topic-title">{{ info.title }}</h2>
+          <div class="info__content" v-html="info.content" />
+          <hr class="info__divider" v-if="information.slice(-1)[0] !== info" />
+        </section>
+      </div>
+      <Button class="info__button" @button-click="close()">OK</Button>
 
-    <div class="check-display">
-      <input
-        type="checkbox"
-        id="DisplayInfo"
-        v-model="displayInfo"
-        name="DisplayInfo"
-        class="check-display__input"
-      />
-      <label class="check-display__checkbox" for="DisplayInfo"
-        ><span class="material-icons">check</span></label
-      >次回のTwin:te起動時に表示する
-    </div>
+      <div class="check-display">
+        <input
+          type="checkbox"
+          id="DisplayInfo"
+          v-model="displayInfo"
+          name="DisplayInfo"
+          class="check-display__input"
+        />
+        <label class="check-display__checkbox" for="DisplayInfo"
+          ><span class="material-icons">check</span></label
+        >次回のTwin:te起動時に表示する
+      </div>
+    </article>
   </Dialog>
 </template>
 
@@ -132,6 +134,13 @@ export default class ModalInfomation extends Vue {
 .info {
   width: 100%;
 
+  &__layout {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+  }
+
   &__title {
     margin-top: 0;
     color: $primary-color;
@@ -148,13 +157,14 @@ export default class ModalInfomation extends Vue {
   }
 
   &__body {
-    height: 73%;
+    position: relative;
+    height: 100%;
     overflow-y: scroll;
     margin-bottom: 5%;
   }
 
   &__post {
-    padding: 3% 5% 0;
+    padding: 4% 3% 0;
   }
 
   &__date {
@@ -166,9 +176,9 @@ export default class ModalInfomation extends Vue {
   &__topic-title {
     @include elipsis;
 
-    color: $info-topic-title-color;
+    color: $yellow-orange;
     font-size: 1.4rem;
-    margin: 0 0 4%;
+    margin: 0 0 3%;
   }
 
   &__content {
@@ -184,9 +194,13 @@ export default class ModalInfomation extends Vue {
       font-size: 1.3rem;
     }
     /deep/ p {
-      margin: 0 0 5%;
+      margin: 0;
       padding: 0;
       line-height: 140%;
+    }
+    /deep/ a {
+      text-decoration: none;
+      color: $link-text-color;
     }
   }
 
@@ -194,7 +208,7 @@ export default class ModalInfomation extends Vue {
     margin: 0;
     padding: 0;
     border: none;
-    border-bottom: 0.1rem solid $element-gray;
+    border-bottom: 0.05rem solid $element-gray;
   }
 }
 
@@ -217,7 +231,7 @@ export default class ModalInfomation extends Vue {
     display: inline-block;
     width: 1.7rem;
     height: 1.7rem;
-    border: 0.14rem solid $unselected-element-color;
+    border: 0.14rem solid $element-gray;
     border-radius: 20% 20%;
     margin-right: 0.8rem;
     cursor: pointer;
@@ -228,7 +242,7 @@ export default class ModalInfomation extends Vue {
       transform: translateY(-50%) translateX(-50%);
       font-size: 100%;
       font-weight: 600;
-      color: $unselected-element-color;
+      color: $element-gray;
       cursor: pointer;
       user-select: none;
     }
@@ -238,7 +252,7 @@ export default class ModalInfomation extends Vue {
     background-color: $primary-color;
     opacity: 1;
     span {
-      color: #fff;
+      color: $white;
       font-weight: 600;
       opacity: 1;
     }

--- a/src/pages/info.vue
+++ b/src/pages/info.vue
@@ -73,15 +73,15 @@ export default class Info extends Vue {
     &__topic-title {
       @include elipsis;
 
-      color: $info-topic-title-color;
+      color: $yellow-orange;
       font-size: 1.4rem;
-      margin: 0 0 4%;
+      margin: 0 0 3%;
     }
     &__content {
       display: inline-block;
       color: $main-text-color;
       font-size: 1.2rem;
-      margin: 0 0 6%;
+      margin: 0;
 
       /deep/ h2 {
         font-size: 1.35rem;
@@ -93,6 +93,10 @@ export default class Info extends Vue {
         margin: 0 0 5%;
         padding: 0;
         line-height: 140%;
+      }
+      /deep/ a {
+        text-decoration: none;
+        color: $link-text-color;
       }
     }
   }


### PR DESCRIPTION
## 概要
お知らせ表示モーダルとお知らせ表示ページの見た目を改善した

## やったこと・変更内容
aタグにスタイル指定した
まだヤバイ部分は残っているが、余白が大きすぎたのやチェックボックス の位置ずれとかを最低限修正した(画像参照)

**before**
iphone6,7,8サイズ
<img width="200px" src="https://user-images.githubusercontent.com/48097323/92333679-68281380-f0c2-11ea-9f6c-2d9e42951b5b.png">

iphone5サイズ
<img width="200px" src="https://user-images.githubusercontent.com/48097323/92333436-75dc9980-f0c0-11ea-87ec-169f5799252e.png">

iPadProサイズ
<img width="290px" src="https://user-images.githubusercontent.com/48097323/92333449-87be3c80-f0c0-11ea-8486-399f6c27c4aa.png">



**after**
iphone6,7,8サイズ
<img width="200px" src="https://user-images.githubusercontent.com/48097323/92333674-61999c00-f0c2-11ea-8b0a-2b29925e4443.png">



iphone5サイズ
<img width="200px" src="https://user-images.githubusercontent.com/48097323/92333442-7bd27a80-f0c0-11ea-859b-3c843d74180e.png">
※わかりやすくするためにここではiphone5サイズでの検証画像にしたが、シェア的に絶滅レベルなのでこのclose-btnの文字との被りは実際にほぼ全てのユーザーが使っている端末(iphone5より大きいもの）では起こらない

iPadProサイズ
<img width="300px" src="https://user-images.githubusercontent.com/48097323/92333455-8d1b8700-f0c0-11ea-9df4-b93bd8908455.png">

- Fix #_

## 確認したこと

- [x] done
Chrome, Safariのレスポンシブモードで確認できる全ての大きさの端末で表示崩れがなくなっていること

- [ ] not

## 備考

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
