### PR TITLE
[fix] material-iconsのカーソルを修正

### DIFF
--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -32,6 +32,10 @@ body {
   width: auto !important;
 }
 
+.material-icons {
+  cursor: default;
+}
+
 /** animation */
 
 .bound-enter-active,


### PR DESCRIPTION
## 概要
material-iconsのカーソルがテキストカーソルになっていたのを、矢印カーソルに修正した。
## やったこと・変更内容
main.scssに、.material-iconのcursorの設定を追加

## 確認したこと
- [x] ローカル環境で実際にカーソルが変化しているのを確認

## 備考
お試しで1行だけですがリクエストしました。
ブランチ名や、その他色々なところ至らない箇所を教えてくれると嬉しいです。