### PR TITLE
モーダルのレイアウト修正

### DIFF
--- a/src/components/app-modal-detail.vue
+++ b/src/components/app-modal-detail.vue
@@ -9,90 +9,93 @@
         <p class="sbj-number">科目番号 {{ table.lecture_code }}</p>
       </h1>
 
-      <!-- 科目詳細 -->
-      <section class="sbj-detail-wrapper">
-        <p class="subject-item">
-          担当教員
-          <span>{{ table.instructor }}</span>
-        </p>
-        <p class="subject-item">
-          開講時限
-          <span>{{ table.module }} {{ table.day }}{{ table.period }}</span>
-        </p>
-        <p class="subject-item">
-          授業教室
-          <span v-if="!editableLecture">{{ table.room }}</span>
-          <input v-else class="sbj-detail" v-model="editableLecture.room" />
-          <i @click="edit()" class="edit-btn material-icons icon">edit</i>
-          <!-- → 教室変更 -->
-        </p>
-        <p class="subject-item" v-if="userData !== null">
-          授業形式
-          <span>
-            <i
-              class="material-icons icon --format"
-              :class="{ '--on': userData.formats.includes('FaceToFace') }"
-              >people_alt</i
-            >
-            <i
-              class="material-icons icon --format"
-              :class="{ '--on': userData.formats.includes('Synchronous') }"
-              >switch_video</i
-            >
-            <i
-              class="material-icons icon --format"
-              :class="{ '--on': userData.formats.includes('Asynchronous') }"
-              >video_library</i
-            >
-            <i
-              @click="changeDisplayFormatPanel"
-              class="material-icons icon --expand"
-              >{{ displayFormatPanel ? 'expand_less' : 'expand_more' }}</i
-            >
-          </span>
-        </p>
-        <FormatsPanel
-          v-show="displayFormatPanel"
-          :formats="localFormats"
-          @change-formats="changeFormats"
-          @reacquisition="reacquisition"
-        />
-      </section>
+      <div class="scroll-area">
+        <!-- 科目詳細 -->
+        <section class="sbj-detail-wrapper">
+          <p class="subject-item">
+            担当教員
+            <span>{{ table.instructor }}</span>
+          </p>
+          <p class="subject-item">
+            開講時限
+            <span>{{ table.module }} {{ table.day }}{{ table.period }}</span>
+          </p>
+          <p class="subject-item">
+            授業教室
+            <span v-if="!editableLecture">{{ table.room }}</span>
+            <input v-else class="sbj-detail" v-model="editableLecture.room" />
+            <i @click="edit()" class="edit-btn material-icons icon">edit</i>
+            <!-- → 教室変更 -->
+          </p>
+          <p class="subject-item" v-if="userData !== null">
+            授業形式
+            <span>
+              <i
+                class="material-icons icon --format"
+                :class="{ '--on': userData.formats.includes('FaceToFace') }"
+                >people_alt</i
+              >
+              <i
+                class="material-icons icon --format"
+                :class="{ '--on': userData.formats.includes('Synchronous') }"
+                >switch_video</i
+              >
+              <i
+                class="material-icons icon --format"
+                :class="{ '--on': userData.formats.includes('Asynchronous') }"
+                >video_library</i
+              >
+              <i
+                @click="changeDisplayFormatPanel"
+                class="material-icons icon --expand"
+                >{{ displayFormatPanel ? 'expand_less' : 'expand_more' }}</i
+              >
+            </span>
+          </p>
+          <FormatsPanel
+            v-show="displayFormatPanel"
+            :formats="localFormats"
+            @change-formats="changeFormats"
+            @reacquisition="reacquisition"
+          />
+        </section>
 
-      <!-- メモ -->
-      <h2>
-        <!-- <i class="material-icons icon">description</i> -->
-        メモ
-      </h2>
-      <textarea class="memo" type="text" v-model="localMemo"></textarea>
-      <h2>
-        出欠管理
-        <span class="assign-btn" @click="attend()">
-          出席する(responへ)
-          <i class="material-icons icon">chevron_right</i>
-        </span>
-      </h2>
-      <section class="counters-wrapper">
-        <div
-          v-for="n in 3"
-          :key="n"
-          :class="{ attend: n === 1, absent: n === 2, late: n === 3 }"
-          style="width: 30%"
-        >
-          <span class="counter-name"
-            >{{ atmnb[n - 1] }} {{ atmnbCount[n - 1] }}回</span
+        <!-- メモ -->
+        <h2>
+          <!-- <i class="material-icons icon">description</i> -->
+          メモ
+        </h2>
+        <textarea class="memo" type="text" v-model="localMemo"></textarea>
+        <h2>
+          出欠管理
+          <span class="assign-btn" @click="attend()">
+            出席する(responへ)
+            <i class="material-icons icon">chevron_right</i>
+          </span>
+        </h2>
+        <section class="counters-wrapper">
+          <div
+            v-for="n in 3"
+            :key="n"
+            :class="{ attend: n === 1, absent: n === 2, late: n === 3 }"
+            style="width: 30%"
           >
-          <!-- <+|-> -->
-          <div class="counter">
-            <span @click="counter(atmnb[n - 1], +1)" class="counter-left"
-              >+</span
+            <span class="counter-name"
+              >{{ atmnb[n - 1] }} {{ atmnbCount[n - 1] }}回</span
             >
-            <span @click="counter(atmnb[n - 1], -1)" class="counter-right"
-              >&#8211;</span
-            >
+            <!-- <+|-> -->
+            <div class="counter">
+              <span @click="counter(atmnb[n - 1], +1)" class="counter-left"
+                >+</span
+              >
+              <span @click="counter(atmnb[n - 1], -1)" class="counter-right"
+                >&#8211;</span
+              >
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
+      <hr class="footer-divider" />
       <div @click="save()" class="register-btn">変更を保存</div>
       <div class="flex">
         <p @click="deleteItem()" class="delete-btn">
@@ -301,7 +304,6 @@ article {
   justify-content: space-between;
   height: 100%;
   width: 100%;
-  overflow-y: scroll;
 }
 
 /* ボタン・アイコン */
@@ -312,6 +314,7 @@ article {
   padding-bottom: 0.4vh;
 
   &.--format {
+    margin-top: -0.7rem;
     font-size: 1.8rem;
     padding: 0.3rem;
     border-radius: 50%;
@@ -320,8 +323,9 @@ article {
   }
 
   &.--expand {
+    margin-top: -0.7rem;
     color: $sub-text-color;
-    font-size: 2rem;
+    font-size: 3rem;
   }
 
   &.--on {
@@ -331,23 +335,25 @@ article {
 
 /* 科目の情報 */
 h1 {
-  height: 6rem;
+  display: block;
+  width: 95%;
   font-size: 1.7rem;
-  line-height: 3.4rem;
+  line-height: 2.5rem;
   font-weight: 500;
   text-overflow: ellipsis;
   border-left: 0.5rem solid $primary-color;
-  white-space: nowrap;
+  padding-top: 0.4rem;
   padding-left: 0.8rem;
-  margin: 0;
+  margin: 0 0 1rem;
   .sbj-number {
     font-size: 1.2rem;
     color: $sub-text-color;
     font-weight: 400;
     line-height: 2rem;
-    margin: 0 0 0.7rem;
+    margin: 0.4rem 0;
   }
 }
+
 h2 {
   width: 100%;
   font-size: 1.4rem;
@@ -360,7 +366,7 @@ h2 {
     margin-right: 1%;
   }
   .assign-btn {
-    position: absolute;
+    // position: absolute;
     font-size: 1.2rem;
     color: $sub-text-color;
     font-weight: 400;
@@ -372,22 +378,35 @@ h2 {
     }
   }
 }
+
+.scroll-area {
+  position: relative;
+  height: 100%;
+  overflow-y: scroll;
+}
 .sbj-detail-wrapper {
   font-size: 1.4rem;
   padding: 0 0.3rem;
-  margin: 0.5rem 0;
 }
 .subject-item {
+  display: flex;
   font-weight: 500;
-  margin: 1.2rem 0;
+  line-height: 1.5rem;
   .edit-btn {
     padding-left: 0.5rem;
     font-size: 1.7rem;
     color: $sub-text-color;
   }
   span {
-    padding-left: 5%;
+    margin-left: 5%;
     font-weight: 400;
+    max-width: 70%;
+  }
+  .sbj-detail {
+    margin-left: 5%;
+    height: 1.8rem;
+    line-height: 1.5rem;
+    max-width: 60%;
   }
 }
 
@@ -395,7 +414,7 @@ h2 {
 
 .memo {
   width: 100%;
-  height: 100%;
+  height: 25%;
   min-height: 10vh;
   color: $main-text-color;
   border: 0.2vh solid $element-gray;
@@ -459,24 +478,33 @@ h2 {
   color: white;
 }
 
+.footer-divider {
+  width: calc(100% + 8vh - 2px);
+  display: block;
+  border: 0.05rem solid $element-gray;
+  box-shadow: 0 -0.5rem 1rem $element-gray;
+  margin: 0 0 1.5rem -4vh;
+  padding: 0;
+}
+
 //++++++++++++++++++++++++// 編集・削除ボタン //++++++++++++++++++++++++//
 .flex {
+  font-size: 1.3rem;
   display: flex;
   justify-content: space-between;
+  margin-bottom: 0;
 }
 .delete-btn {
-  font-size: 1.3rem;
   color: $element-denger;
-  margin: 2vh 0 0;
   /* stylelint-disable-next-line no-descending-specificity */
   i {
     font-size: 2rem;
   }
 }
 .syllabus-btn {
-  font-size: 1.3rem;
+  position: absolute;
+  right: 0;
   color: $primary-color;
-  margin: 2vh 0 0;
   /* stylelint-disable-next-line no-descending-specificity */
   i {
     font-size: 2rem;

--- a/src/components/def-modal-add.vue
+++ b/src/components/def-modal-add.vue
@@ -71,6 +71,7 @@
         </p>
       </section>
       <!-- → その他オプション -->
+      <hr class="footer-divider" />
       <section class="register-btn" @click="submitByNumber()">
         時間割に追加
       </section>
@@ -451,5 +452,13 @@ article {
     color: $primary-color;
     font-size: 1.9rem;
   }
+}
+.footer-divider {
+  width: calc(100% + 8vh - 2px);
+  display: block;
+  border: 0.05rem solid $element-gray;
+  box-shadow: 0 -0.5rem 1rem $element-gray;
+  margin: 0 0 1.5rem -4vh;
+  padding: 0;
 }
 </style>

--- a/src/components/def-modal-information.vue
+++ b/src/components/def-modal-information.vue
@@ -10,6 +10,7 @@
           <hr class="info__divider" v-if="information.slice(-1)[0] !== info" />
         </section>
       </div>
+      <hr class="footer-divider" />
       <Button class="info__button" @button-click="close()">OK</Button>
 
       <div class="check-display">
@@ -160,7 +161,6 @@ export default class ModalInfomation extends Vue {
     position: relative;
     height: 100%;
     overflow-y: scroll;
-    margin-bottom: 5%;
   }
 
   &__post {
@@ -210,6 +210,15 @@ export default class ModalInfomation extends Vue {
     border: none;
     border-bottom: 0.05rem solid $element-gray;
   }
+}
+
+.footer-divider {
+  width: calc(100% + 8vh - 2px);
+  display: block;
+  border: 0.05rem solid $element-gray;
+  box-shadow: 0 -0.5rem 1rem $element-gray;
+  margin: 0 0 1.5rem -4vh;
+  padding: 0;
 }
 
 .check-display {

--- a/src/components/global/FormatsPanel.vue
+++ b/src/components/global/FormatsPanel.vue
@@ -105,13 +105,15 @@ export default class FormatsPanel extends Vue {
   border: 0.14rem solid $element-gray;
   border-radius: 0.4rem;
   padding: 1rem;
+  margin-top: -1rem;
+  left: 0;
 
   &__section {
     margin-top: 1.2rem;
   }
 
   &__title {
-    font-size: 1.1rem;
+    font-size: 1.3rem;
     color: $sub-text-color;
   }
 
@@ -125,8 +127,6 @@ export default class FormatsPanel extends Vue {
   display: inline-flex;
   vertical-align: middle;
   padding-bottom: 0.4vh;
-  height: 1.4rem;
-  width: 1.4rem;
 
   &.--refresh {
     font-size: 1.7rem;
@@ -134,7 +134,7 @@ export default class FormatsPanel extends Vue {
   }
 
   &.--format {
-    font-size: 1.4rem;
+    font-size: 1.8rem;
     padding: 0.3rem;
     border-radius: 50%;
     color: $element-pale-gray;
@@ -148,6 +148,8 @@ export default class FormatsPanel extends Vue {
 
 .checkbox {
   display: flex;
+  vertical-align: middle;
+  align-items: center;
 
   &__input {
     display: none;
@@ -185,18 +187,18 @@ export default class FormatsPanel extends Vue {
   }
   &__contents {
     line-height: 1.7rem;
-    font-size: 1rem;
-    margin-left: 0.4rem;
+    font-size: 1.2rem;
+    margin-left: 0.5rem;
   }
 }
 
 .reacquisition {
   line-height: 1.7rem;
-  font-size: 1.2rem;
+  font-size: 1.3rem;
 
   &__sub-title {
     margin-left: 2.5rem;
-    font-size: 0.9rem;
+    font-size: 1rem;
     color: $sub-text-color;
   }
 }


### PR DESCRIPTION
## 概要
授業詳細モーダルの崩れを直した。

## やったこと・変更内容
**after**
<img width="300px" src="https://user-images.githubusercontent.com/48097323/95771072-666ef280-0cf5-11eb-9476-6c995a3b6a52.gif">
**before**
<img width="300px" src="https://user-images.githubusercontent.com/48097323/95771404-f319b080-0cf5-11eb-8c1f-741c7ba6ad1f.gif">

- 科目名や保存するボタンをスクロール領域から省いた。
- 画面サイズに左右されていた出欠ボタンの位置をずれないようにした。
- 授業名が長い場合に省略されてしまっていたのを、改行して全て表示されるようにした。
- 教員名が長い場合にインデントを無視して回り込んで改行されてしまっていたのを修正
- 授業場所編集モードで出現するテキストフィールドの位置を修正
- 授業詳細モーダルを含めたモーダル全てで、スクロールする領域との差別化を図るためにregister-btn以下の領域を固定footerのように位置付けた。そのためにラインで区切った(画像参照)。

- 授業形式ポップアップの文字を少し大きくした(これは普通にデザインの段階でのミスです)

## 確認したこと

- [x] safariで崩れない


## 備考
出欠ボタンがめり込む問題の応急処置のつもりだったが、モーダルの根本的なレイアウト指定に起因する問題だったので、全体的な見直しも含まれている。
端末によっては出欠ボタンが半分以上隠れてしまっているため、この修正は早急にprdに反映されて欲しく、devを経由せず先にmasterへmergeしたい。(後日rebaseします)

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
