### PR TITLE
[add] 科目検索結果にも授業形式アイコンを表示

### DIFF
--- a/src/components/def-modal-add.vue
+++ b/src/components/def-modal-add.vue
@@ -508,7 +508,7 @@ article {
     }
   }
   .syllabus-btn {
-    margin: 0 -10px 0 -3px;
+    margin: 0 -8px 0 -3px;
     color: $sub-text-color;
     font-size: 24px;
   }

--- a/src/components/def-modal-add.vue
+++ b/src/components/def-modal-add.vue
@@ -49,8 +49,31 @@
               n.lecture_name
             }}</label>
           </div>
+          <div class="result-formats">
+            <i
+              class="material-icons icon result-formats__icon"
+              :class="{
+                'result-formats__icon--on': n.formats.includes('FaceToFace'),
+              }"
+              >people_alt</i
+            >
+            <i
+              class="material-icons icon result-formats__icon"
+              :class="{
+                'result-formats__icon--on': n.formats.includes('Synchronous'),
+              }"
+              >switch_video</i
+            >
+            <i
+              class="material-icons icon result-formats__icon"
+              :class="{
+                'result-formats__icon--on': n.formats.includes('Asynchronous'),
+              }"
+              >video_library</i
+            >
+          </div>
           <span @click="syllabus(n)" class="syllabus-btn material-icons"
-            >menu_book</span
+            >chevron_right</span
           >
         </div>
       </section>
@@ -98,6 +121,7 @@ type miniLecture = {
   day: string
   period: number
   checked: boolean
+  formats: string[]
 }
 
 @Component({
@@ -180,6 +204,7 @@ export default class Index extends Vue {
         module: l.details[0]?.module || '',
         day: l.details[0]?.day || '',
         period: l.details[0]?.period || 0,
+        formats: l.formats,
         checked: type === 'csv',
       }
     })
@@ -397,6 +422,7 @@ article {
     display: none;
   }
   &__checkbox {
+    flex: 0 0 auto;
     position: relative;
     display: inline-block;
     width: 1.7rem;
@@ -418,9 +444,26 @@ article {
     }
   }
   .result-content {
-    width: 90%;
+    flex: 1 1 auto;
     display: flex;
     flex-direction: column;
+  }
+  .result-formats {
+    height: 100%;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    &__icon {
+      font-size: 1.8rem;
+      margin-left: 5px;
+      padding: 0.3rem;
+      border-radius: 50%;
+      color: $element-pale-gray;
+      background: $element-light-gray;
+      &--on {
+        background: $yellow-orange-light;
+      }
+    }
   }
   &__lecture-name {
     color: $emphasis-text-color;
@@ -448,9 +491,9 @@ article {
     }
   }
   .syllabus-btn {
-    padding-left: 0.3rem;
-    color: $primary-color;
-    font-size: 1.9rem;
+    margin: 0 -0.4rem 0 -2px;
+    color: $sub-text-color;
+    font-size: 3rem;
   }
 }
 .footer-divider {

--- a/src/components/def-modal-add.vue
+++ b/src/components/def-modal-add.vue
@@ -448,23 +448,6 @@ article {
     display: flex;
     flex-direction: column;
   }
-  .result-formats {
-    height: 100%;
-    flex: 0 0 auto;
-    display: flex;
-    align-items: center;
-    &__icon {
-      font-size: 1.8rem;
-      margin-left: 5px;
-      padding: 0.3rem;
-      border-radius: 50%;
-      color: $element-pale-gray;
-      background: $element-light-gray;
-      &--on {
-        background: $yellow-orange-light;
-      }
-    }
-  }
   &__lecture-name {
     color: $emphasis-text-color;
     font-size: 1.35rem;
@@ -490,10 +473,27 @@ article {
       opacity: 1;
     }
   }
+  .result-formats {
+    height: 100%;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    &__icon {
+      font-size: 14px;
+      margin-left: 5px;
+      padding: 0.3rem;
+      border-radius: 50%;
+      color: $element-pale-gray;
+      background: $element-light-gray;
+      &--on {
+        background: $yellow-orange-light;
+      }
+    }
+  }
   .syllabus-btn {
     margin: 0 -0.4rem 0 -2px;
     color: $sub-text-color;
-    font-size: 3rem;
+    font-size: 24px;
   }
 }
 .footer-divider {

--- a/src/components/def-modal-add.vue
+++ b/src/components/def-modal-add.vue
@@ -5,14 +5,14 @@
   -->
   <Dialog :show="show" @close="close()">
     <article>
-      <h1 class="title">授業の追加</h1>
+      <h1 class="title"><i class="title--icon material-icons">add</i> 授業の追加</h1>
 
       <!-- 検索フォーム -->
       <form class="search-form" @submit.prevent>
         <input
           v-model="input"
           type="text"
-          placeholder="授業名や科目番号で検索"
+          placeholder="授業名/科目番号で検索"
           class="search-form__form"
           @keyup.enter="search(input, 'input')"
         />
@@ -322,10 +322,15 @@ article {
 
 /* 授業の追加 */
 .title {
+  display: flex;
+  align-items: center;
   font-size: 1.8rem;
   color: $primary-color;
   font-weight: 400;
   margin: 0 0 1.5vh;
+  &--icon {
+    font-size: 30px;
+  }
 }
 
 /* 検索フォーム */
@@ -410,9 +415,21 @@ article {
   scrollbar-width: thin;
   box-sizing: border-box;
   .result-wrap {
-    padding: 0.8rem 1rem;
+    position: relative;
+    padding: 11px 1rem;
     display: flex;
     align-items: center;
+    &::after {
+      $w: 1rem;
+
+      content: "";
+      position: absolute;
+      bottom: 0;
+      left: $w;
+      width: calc(100% - (#{$w} * 2));
+      height: 0.5px;
+      background-color: $element-gray;
+    }
   }
   &__label {
     display: inline-block;
@@ -491,7 +508,7 @@ article {
     }
   }
   .syllabus-btn {
-    margin: 0 -0.4rem 0 -2px;
+    margin: 0 -10px 0 -3px;
     color: $sub-text-color;
     font-size: 24px;
   }

--- a/src/components/def-modal-add.vue
+++ b/src/components/def-modal-add.vue
@@ -53,21 +53,21 @@
             <i
               class="material-icons icon result-formats__icon"
               :class="{
-                'result-formats__icon--on': n.formats.includes('FaceToFace'),
+                '--on': n.formats.includes('FaceToFace'),
               }"
               >people_alt</i
             >
             <i
               class="material-icons icon result-formats__icon"
               :class="{
-                'result-formats__icon--on': n.formats.includes('Synchronous'),
+                '--on': n.formats.includes('Synchronous'),
               }"
               >switch_video</i
             >
             <i
               class="material-icons icon result-formats__icon"
               :class="{
-                'result-formats__icon--on': n.formats.includes('Asynchronous'),
+                '--on': n.formats.includes('Asynchronous'),
               }"
               >video_library</i
             >
@@ -502,7 +502,7 @@ article {
       border-radius: 50%;
       color: $element-pale-gray;
       background: $element-light-gray;
-      &--on {
+      &.--on {
         background: $yellow-orange-light;
       }
     }


### PR DESCRIPTION
## 概要
検索結果表示にも授業形式アイコンを追加しました。

## やったこと・変更内容
- 検索結果表示に授業形式アイコンを追加
- シラバス参照のボタンのアイコンを変更
- 長い授業名だった場合に折り返すようにしました。
![image](https://user-images.githubusercontent.com/45098934/96061496-55c5a480-0ece-11eb-873c-2130ae704182.png)

- Fix #191 

## 確認したこと

- [x] 実際に検索してたしかめた

## 備考
- 授業のフォーマットデータはすでにありました。
- TypeScriptを勉強し始めたばかりなので、特にJSのコードが問題ないか確認してほしいです。
- デザインで修正がありましたら遠慮なくどうぞ！

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
