### PR TITLE
以前に作ったコンポーネントを lint type-check に適合するように修正

### DIFF
--- a/src/components/Checkbox.vue
+++ b/src/components/Checkbox.vue
@@ -16,6 +16,7 @@ export default defineComponent({
       default: false,
     },
   },
+  emits: ["click-checkbox"],
   setup: (_, { emit }) => {
     const handleClick = (e: MouseEvent) => {
       emit("click-checkbox", e);

--- a/src/components/TextFieldMultilines.vue
+++ b/src/components/TextFieldMultilines.vue
@@ -1,12 +1,6 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
-type Props = {
-  placeholder: string;
-  width: number;
-  height: number;
-};
-
 export default defineComponent({
   props: {
     modelValue: {
@@ -27,7 +21,7 @@ export default defineComponent({
     },
   },
   emits: ["update:modelValue", "enter-text-field"],
-  setup: (props: Props, { emit }) => {
+  setup: (_, { emit }) => {
     const handleInput = (e: Event) => {
       if (!(e.target instanceof HTMLTextAreaElement)) {
         return;

--- a/src/components/TextFieldSingleLine.vue
+++ b/src/components/TextFieldSingleLine.vue
@@ -17,6 +17,7 @@ export default defineComponent({
     },
     onEnterTextField: {
       type: Function,
+      default: () => {},
     },
     placeholder: {
       type: String,

--- a/src/components/ToggleButton.vue
+++ b/src/components/ToggleButton.vue
@@ -31,9 +31,8 @@ export default defineComponent({
       default: false,
     },
   },
+  emits: ["click-toggle-button"],
   setup: (props: Props, { emit }) => {
-    const labels = props.labels;
-
     const handleChange = (select: Select, e: MouseEvent) => {
       emit("click-toggle-button", select, e);
     };
@@ -42,7 +41,7 @@ export default defineComponent({
       return props.whichSelected == "left";
     });
 
-    return { handleChange, isSelectLeft, labels };
+    return { handleChange, isSelectLeft };
   },
 });
 </script>

--- a/src/components/ToggleSwitch.vue
+++ b/src/components/ToggleSwitch.vue
@@ -16,6 +16,7 @@ export default defineComponent({
       default: false,
     },
   },
+  emits: ["click-toggle-switch"],
   setup: (_, { emit }) => {
     const handleChange = (e: MouseEvent) => {
       emit("click-toggle-switch", e);


### PR DESCRIPTION
## 概要
以前つくった諸々のコンポーネントが lint と type-check に怒られていたので解決しました。

## やったこと・変更内容
以下 lint による warnig と error を修正
```
twinte-front $ yarn lint --fix
yarn run v1.22.10
$ eslint --ext .vue ./src --fix

/mnt/d/works/twinte/twinte-front/src/components/Checkbox.vue
  21:12  warning  The "click-checkbox" event has been triggered but not declared on `emits` option  vue/require-explicit-emits

/mnt/d/works/twinte/twinte-front/src/components/TextFieldSingleLine.vue
  18:5  warning  Prop 'onEnterTextField' requires default value to be set  vue/require-default-prop     

/mnt/d/works/twinte/twinte-front/src/components/ToggleButton.vue
  35:11  error    Getting a value from the `props` in root scope of `setup()` will cause the value to lose reactivity  vue/no-setup-props-destructure
  38:12  warning  The "click-toggle-button" event has been triggered but not declared on `emits` option 
               vue/require-explicit-emits
  45:42  error    Duplicated key 'labels'
               vue/no-dupe-keys

/mnt/d/works/twinte/twinte-front/src/components/ToggleSwitch.vue
  21:12  warning  The "click-toggle-switch" event has been triggered but not declared on `emits` option 
 vue/require-explicit-emits

✖ 6 problems (2 errors, 4 warnings)
```


## 確認したこと

- [x] `yarn lint & type-check`

## 備考

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
