### PR TITLE
fix layout of the preview

### DIFF
--- a/src/pages/add/index.vue
+++ b/src/pages/add/index.vue
@@ -1,11 +1,19 @@
 <template>
-  <Button @click="clickHandler" size="small">Back to Home</Button>
-  <Button @click="openModal" size="small">Open Modal</Button>
-  <Modal v-if="modal" @click="closeModal" size="large">
-    <div class="title">title</div>
-    <div class="contents">contents</div>
-    <Button @click="closeModal" layout="fill" size="medium">OK</Button>
-  </Modal>
+  <article class="preview">
+    <section class="preview__content">
+      <Button @click="clickHandler" size="small">Back to Home</Button>
+    </section>
+    <section class="preview__content">
+      <Button @click="openModal" size="small">Open Modal</Button>
+    </section>
+    <section class="preview__content">
+      <Modal v-if="modal" @click="closeModal" size="large">
+        <div class="title">title</div>
+        <div class="contents">contents</div>
+        <Button @click="closeModal" layout="fill" size="medium">OK</Button>
+      </Modal>
+    </section>
+  </article>
 </template>
 
 <script lang="ts">

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,85 +1,100 @@
 <template>
-  <div v-if="ready">{{ state ? "logined" : "not login" }}</div>
-  <div v-else>loading...</div>
+  <article class="preview">
+    <div v-if="ready">
+      {{ state ? "logined" : "not login" }}
+    </div>
+    <div v-else>loading...</div>
 
-  <Button @click="$router.push('/add')" size="small">Go to Add Page</Button>
+    <section class="preview__content">
+      <Button @click="$router.push('/add')" size="small">Go to Add Page</Button>
+    </section>
+    <section class="preview__content--flex">
+      <ToggleIconButton
+        @click="isBtnActive.expand_more = !isBtnActive.expand_more"
+        size="small"
+        color="normal"
+        icon-name="expand_more"
+        :is-active="isBtnActive.expand_more"
+      ></ToggleIconButton>
 
-  <ToggleIconButton
-    @click="isBtnActive.expand_more = !isBtnActive.expand_more"
-    size="small"
-    color="normal"
-    icon-name="expand_more"
-    :is-active="isBtnActive.expand_more"
-  ></ToggleIconButton>
+      <ToggleIconButton
+        @click="isBtnActive.edit = !isBtnActive.edit"
+        size="medium"
+        color="normal"
+        icon-name="edit"
+        :is-active="isBtnActive.edit"
+      ></ToggleIconButton>
 
-  <ToggleIconButton
-    @click="isBtnActive.edit = !isBtnActive.edit"
-    size="medium"
-    color="normal"
-    icon-name="edit"
-    :is-active="isBtnActive.edit"
-  ></ToggleIconButton>
+      <ToggleIconButton
+        @click="isBtnActive.menu = !isBtnActive.menu"
+        size="large"
+        color="normal"
+        icon-name="menu"
+        :is-active="isBtnActive.menu"
+      ></ToggleIconButton>
 
-  <ToggleIconButton
-    @click="isBtnActive.menu = !isBtnActive.menu"
-    size="large"
-    color="normal"
-    icon-name="menu"
-    :is-active="isBtnActive.menu"
-  ></ToggleIconButton>
+      <IconButton
+        @click="clickHandler"
+        size="large"
+        color="danger"
+        icon-name="delete"
+      ></IconButton>
+    </section>
 
-  <IconButton
-    @click="clickHandler"
-    size="large"
-    color="danger"
-    icon-name="delete"
-  ></IconButton>
+    <section class="preview__content">
+      <div class="course-grid">
+        <CourseTile
+          @click="tileStat = tileStat == 'active' ? 'default' : 'active'"
+          :state="tileStat"
+          courseName="学校を考える"
+          courseId="1A101"
+        ></CourseTile>
 
-  <div class="course-grid">
-    <CourseTile
-      @click="tileStat = tileStat == 'active' ? 'default' : 'active'"
-      :state="tileStat"
-      courseName="学校を考える"
-      courseId="1A101"
-    ></CourseTile>
+        <CourseTile
+          state="active"
+          courseName="学校を考える"
+          courseId="1A101"
+        ></CourseTile>
 
-    <CourseTile
-      state="active"
-      courseName="学校を考える"
-      courseId="1A101"
-    ></CourseTile>
+        <CourseTile state="none" courseName="" courseId=""></CourseTile>
 
-    <CourseTile state="none" courseName="" courseId=""></CourseTile>
+        <CourseTile
+          state="default"
+          courseName="学校を考える"
+          courseId="1A101"
+          caution="他1件"
+        ></CourseTile>
+      </div>
+    </section>
 
-    <CourseTile
-      state="default"
-      courseName="学校を考える"
-      courseId="1A101"
-      caution="他1件"
-    ></CourseTile>
-  </div>
+    <section class="preview__content">
+      <div class="course-details">
+        <CourseDetail
+          iconName="schedule"
+          item="開講時限"
+          value="春AB 木2"
+        ></CourseDetail>
 
-  <div class="course-details">
-    <CourseDetail
-      iconName="schedule"
-      item="開講時限"
-      value="春AB 木2"
-    ></CourseDetail>
+        <CourseDetail
+          iconName="person"
+          item="担当教員"
+          value="山本早里"
+        ></CourseDetail>
 
-    <CourseDetail
-      iconName="person"
-      item="担当教員"
-      value="山本早里"
-    ></CourseDetail>
+        <CourseDetail
+          iconName="room"
+          item="授業場所"
+          value="6A508"
+        ></CourseDetail>
 
-    <CourseDetail iconName="room" item="授業場所" value="6A508"></CourseDetail>
-
-    <CourseDetail
-      iconName="category"
-      item="授業形式"
-      value="対面"
-    ></CourseDetail>
-  </div>
+        <CourseDetail
+          iconName="category"
+          item="授業形式"
+          value="対面"
+        ></CourseDetail>
+      </div>
+    </section>
+  </article>
 </template>
 
 <script lang="ts">

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -11,6 +11,7 @@ html {
   font-family: "Noto Sans JP", Arial, Helvetica, sans-serif;
   box-sizing: border-box;
   color: $text-main;
+  background: $base-liner;
 }
 @include tab-and-pc {
   html {
@@ -23,4 +24,21 @@ body {
 .material-icons {
   font-family: Material Icons;
   @include iconlayout;
+}
+.preview {
+  width: 375px;
+  padding: 4rem;
+  display: flex;
+  flex-direction: column;
+  flex-basis: 0;
+  flex-shrink: 1;
+  &__content {
+    margin: 2rem;
+    &--flex {
+      margin: 2rem;
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+    }
+  }
 }


### PR DESCRIPTION
## 概要
preview画面のの見た目をちゃんとさせた

## やったこと・変更内容
本来のbackground-colorをつけた
余白がなくて苦しかったので余白を設けた
ちゃんと並べた

|after|before|
|---|---|
|<img width="335" alt="スクリーンショット 2021-02-11 14 22 07" src="https://user-images.githubusercontent.com/48097323/107605035-4d5f5980-6c75-11eb-80c7-9df2d3a518b6.png">|<img width="316" alt="スクリーンショット 2021-02-11 14 23 17" src="https://user-images.githubusercontent.com/48097323/107605029-49333c00-6c75-11eb-82d3-64250793577a.png">|
|<img width="316" alt="スクリーンショット 2021-02-11 14 22 28" src="https://user-images.githubusercontent.com/48097323/107605061-61a35680-6c75-11eb-826f-804d104401d3.png">|<img width="316" alt="スクリーンショット 2021-02-11 14 23 09" src="https://user-images.githubusercontent.com/48097323/107605046-56502b00-6c75-11eb-993d-a5d07f758b9e.png">|

## 確認したこと
- [x] 副作用がないこと

## 備考
preview用のページはこれから増えていくはずなのでとりまmainに書いてしまった

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
