### PR TITLE
Fix page header

### DIFF
--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -17,7 +17,7 @@ export default defineComponent({
     },
     calendar: {
       type: Object as PropType<Calendar>,
-      default: {},
+      default: { month: 4, day: 1, week: "木", schdule: "休日" },
     },
   },
   emits: ["click"],

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -1,13 +1,5 @@
 <script lang="ts">
-import { defineComponent, ref, PropType } from "vue";
-import IconButton from "./IconButton.vue";
-import ToggleIconButton from "./ToggleIconButton.vue";
-
-type Props = {
-  onClick: Function;
-  atHome: boolean;
-  dropdownMenu: boolean;
-};
+import { defineComponent, PropType } from "vue";
 
 export type Calendar = {
   month: number;
@@ -18,40 +10,22 @@ export type Calendar = {
 
 export default defineComponent({
   name: "PageHeader",
-  components: {
-    IconButton,
-    ToggleIconButton,
-  },
   props: {
-    onClick: {
-      type: Function,
-      default: () => {},
-    },
     atHome: {
-      type: Boolean,
-      default: false,
-    },
-    dropdownMenu: {
       type: Boolean,
       default: false,
     },
     calendar: {
       type: Object as PropType<Calendar>,
-      required: true,
+      default: {},
     },
   },
   emits: ["click"],
-  setup: (_: Props, { emit }) => {
+  setup: (_, { emit }) => {
     const handleClick = () => {
       emit("click");
     };
-    const isBtnActive = ref({
-      expand: false,
-    });
-    return {
-      isBtnActive,
-      handleClick,
-    };
+    return { handleClick };
   },
 });
 </script>
@@ -59,33 +33,23 @@ export default defineComponent({
 <template>
   <header class="header">
     <div class="header__container">
-      <IconButton
-        class="header__menu-icon"
-        @click="handleClick"
-        size="large"
-        color="normal"
-        icon-name="menu"
-      ></IconButton>
+      <div class="header__menu-icon">
+        <slot name="left-btn"></slot>
+      </div>
       <div v-if="atHome">
         <img class="header__title--logo" src="../assets/twintelogo-color.svg" />
       </div>
       <h1 class="header__title" v-else>
-        <slot />
+        <slot name="title"></slot>
       </h1>
-      <ToggleIconButton
-        class="header__dropdown-menu-icon"
-        @click="isBtnActive.expand = !isBtnActive.expand"
-        v-if="dropdownMenu"
-        size="large"
-        color="normal"
-        icon-name="more_vert"
-        :is-active="isBtnActive.expand"
-      ></ToggleIconButton>
       <div class="header__calendar" v-if="atHome">
         <p class="header__date">
           {{ calendar.month }}/{{ calendar.day }} ({{ calendar.week }})
         </p>
         <p class="header__schedule">{{ calendar.schedule }}</p>
+      </div>
+      <div class="header__dropdown-menu-icon" v-else>
+        <slot name="right-btn"></slot>
       </div>
     </div>
   </header>

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -80,6 +80,14 @@ export default defineComponent({
     left: 50%;
     transform: translateX(-50%);
     bottom: 0.3rem;
+    font-size: 1.6rem;
+    font-weight: 500;
+    line-height: $single-line;
+    color: $text-main;
+    @include wide-screen {
+      left: 0;
+      transform: translateX(0);
+    }
     &--logo {
       position: absolute;
       left: 50%;

--- a/src/pages/preview.vue
+++ b/src/pages/preview.vue
@@ -181,7 +181,7 @@
       </Modal>
     </section>
     <PageHeader
-      :atHome="true"
+      atHome
       :calendar="{ month: 2, day: 23, week: '火', schedule: '通常日課' }"
     >
       <template #left-btn>
@@ -193,8 +193,8 @@
         ></IconButton>
       </template>
     </PageHeader>
-    <PageHeader :atHome="false"
-      ><template #left-btn>
+    <PageHeader>
+      <template #left-btn>
         <IconButton
           @click="clickHandler"
           size="large"
@@ -210,8 +210,9 @@
           color="normal"
           icon-name="more_vert"
           :is-active="isBtnActive.more_vert"
-        ></ToggleIconButton> </template
-    ></PageHeader>
+        ></ToggleIconButton>
+      </template>
+    </PageHeader>
   </article>
 </template>
 

--- a/src/pages/preview.vue
+++ b/src/pages/preview.vue
@@ -171,7 +171,7 @@
             >Button</Button
           >
           <Button
-            @click="closeModal"
+            @click="clickHandler"
             layout="fill"
             size="medium"
             color="primary"
@@ -180,6 +180,38 @@
         </template>
       </Modal>
     </section>
+    <PageHeader
+      :atHome="true"
+      :calendar="{ month: 2, day: 23, week: '火', schedule: '通常日課' }"
+    >
+      <template #left-btn>
+        <IconButton
+          @click="clickHandler"
+          size="large"
+          color="normal"
+          icon-name="menu"
+        ></IconButton>
+      </template>
+    </PageHeader>
+    <PageHeader :atHome="false"
+      ><template #left-btn>
+        <IconButton
+          @click="clickHandler"
+          size="large"
+          color="normal"
+          icon-name="arrow_back"
+        ></IconButton>
+      </template>
+      <template #title>授業詳細</template>
+      <template #right-btn>
+        <ToggleIconButton
+          @click="isBtnActive.more_vert = !isBtnActive.more_vert"
+          size="large"
+          color="normal"
+          icon-name="more_vert"
+          :is-active="isBtnActive.more_vert"
+        ></ToggleIconButton> </template
+    ></PageHeader>
   </article>
 </template>
 
@@ -204,6 +236,7 @@ import PopupContent, {
   Color as PopupContentColor,
 } from "../components/PopupContent.vue";
 import Modal from "../components/Modal.vue";
+import PageHeader from "../components/PageHeader.vue";
 
 export default defineComponent({
   name: "Preview",
@@ -221,6 +254,7 @@ export default defineComponent({
     Popup,
     PopupContent,
     Modal,
+    PageHeader,
   },
   setup: () => {
     const { ready, state } = useUsecase(authCheck, true);
@@ -228,6 +262,7 @@ export default defineComponent({
       expand_more: false,
       edit: false,
       menu: false,
+      more_vert: false,
     });
     const courseInfo = ref<Course>({
       id: "01EB512",
@@ -308,6 +343,10 @@ export default defineComponent({
       modal.value = false;
     };
 
+    const clickHandler = () => {
+      console.log("click");
+    };
+
     return {
       displayLog,
       isBtnActive,
@@ -321,6 +360,7 @@ export default defineComponent({
       modal,
       openModal,
       closeModal,
+      clickHandler,
     };
   },
 });


### PR DESCRIPTION
## 概要
page-headerをhome以外のページに対応させた。

## やったこと・変更内容
- 左側のボタンのアイコンを変更できるようにした。
- 右側のボタンのstateの管理を親コンポーネントができるようにした。

## 備考
preview.vueで確認できます。
PageHeaderとpreview.vueのPageHeaderの部分以外のコードは、add-popupと同じです。

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
