### PR TITLE
Set layout

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -94,6 +94,9 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import "../scss/main.scss";
 .sidebar {
+  display: flex;
+  flex-direction: column;
+  top: 0;
   left: 0;
   width: 20.8rem;
   height: 100vh;
@@ -108,7 +111,9 @@ export default defineComponent({
     padding: 6.2rem 2rem 2rem;
   }
   &__contents {
-    margin: 0;
+    margin: 0 0 $spacing-10;
+    overflow-y: auto;
+    overflow-x: hidden;
   }
   &__listgroup {
     padding-bottom: $spacing-6;

--- a/src/scss/_variable.scss
+++ b/src/scss/_variable.scss
@@ -51,6 +51,8 @@ $spacing-5: 2rem;
 $spacing-6: 2.4rem;
 $spacing-7: 2.8rem;
 $spacing-8: 3.2rem;
+$spacing-9: 3.6rem;
+$spacing-10: 4rem;
 
 // font-size
 $font-minimum: 1rem;


### PR DESCRIPTION
mainに反映されていない分
(set-layoutを含めるということでmergeされたadd-page-homeに最新のものがrebaseされていなかったため)

Sideberのcontentsが画面の縦幅を超えた場合、Contentsの表示領域内でスクロールするようにした

|端末の「スクロールバーを常に表示」がonの場合|端末の「スクロールバーを常に表示」がoffの場合|
|---|---|
|![画面収録-2021-03-03-15 22 06](https://user-images.githubusercontent.com/48097323/109763559-96337e00-7c35-11eb-9d2f-a4660de542a8.gif)| ![画面収録-2021-03-03-15 22 35](https://user-images.githubusercontent.com/48097323/109763578-9d5a8c00-7c35-11eb-8d85-8c9b4f5fa3d2.gif)|
