### PR TITLE
Add details logic

### DIFF
--- a/src/components/DropdownAddable.vue
+++ b/src/components/DropdownAddable.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
 import { defineComponent, PropType, watch } from "vue";
 import DropDown from "~/components/Dropdown.vue";
-import { methodOption, createOption } from "~/entities/method";
+import { MethodOption, createOption } from "~/entities/method";
 
 type Props = {
   onClickAddButton: Function;
   onClickRemoveButton: Function;
-  methods: { value: methodOption }[];
+  methods: { value: MethodOption }[];
 };
 
 export default defineComponent({
@@ -24,7 +24,7 @@ export default defineComponent({
       required: true,
     },
     methods: {
-      type: Array as PropType<{ value: methodOption }[]>,
+      type: Array as PropType<{ value: MethodOption }[]>,
       required: true,
     },
   },

--- a/src/components/ScheduleEditer.vue
+++ b/src/components/ScheduleEditer.vue
@@ -1,13 +1,7 @@
 <script lang="ts">
 import { defineComponent, PropType, ref } from "vue";
+import { Schedule } from "~/entities/schedule";
 import Dropdown, { Options as DropdownOptions } from "./Dropdown.vue";
-
-export type Schedule = {
-  semester: string;
-  date: string;
-  period: string;
-};
-export type Schedules = Schedule[];
 
 export default defineComponent({
   components: { Dropdown },
@@ -21,7 +15,7 @@ export default defineComponent({
       required: true,
     },
     schedules: {
-      type: Object as PropType<Schedules>,
+      type: Object as PropType<Schedule[]>,
       required: true,
     },
   },
@@ -85,12 +79,12 @@ export default defineComponent({
       <div class="schedule-editer__container">
         <Dropdown
           :options="semesterOptions"
-          v-model:selectedOption="schedule.semester"
+          v-model:selectedOption="schedule.module"
           :label="index > 0 ? '' : '学期'"
         ></Dropdown>
         <Dropdown
           :options="dateOptions"
-          v-model:selectedOption="schedule.date"
+          v-model:selectedOption="schedule.day"
           :label="index > 0 ? '' : '曜日'"
         ></Dropdown>
         <Dropdown

--- a/src/entities/course.ts
+++ b/src/entities/course.ts
@@ -1,0 +1,116 @@
+import { RegisteredCourse, CourseSchedule } from "~/api/@types";
+import { methodMap } from "./method";
+
+export type DisplayCourse = {
+  code: string;
+  name: string;
+  date: string;
+  instructor: string;
+  room: string;
+  methods: string;
+  courseId: string;
+  memo: string;
+  attendance: number;
+  absence: number;
+  late: number;
+  registeredCourse: RegisteredCourse;
+};
+
+export const displayCourseToApi = (
+  displayedCourse: DisplayCourse
+): RegisteredCourse => ({
+  ...displayedCourse.registeredCourse,
+  attendance: displayedCourse.attendance,
+  absence: displayedCourse.absence,
+  late: displayedCourse.late,
+  memo: displayedCourse.memo,
+  name: displayedCourse.name,
+});
+
+export const apiToDisplayCourse = (
+  registeredCourse: RegisteredCourse
+): DisplayCourse => ({
+  code: registeredCourse?.course?.code ?? "-",
+  name: registeredCourse?.name ?? registeredCourse?.course?.name ?? "-",
+  date:
+    getLectureTimeAsStr(registeredCourse?.course?.schedules ?? []) ?? "undef",
+  instructor:
+    registeredCourse?.instructor ?? registeredCourse?.course?.instructor ?? "-",
+  room:
+    registeredCourse?.course?.schedules.map((s) => s.room).join(", ") ?? "-",
+  methods:
+    registeredCourse?.methods?.map((c) => methodMap[c]).join(", ") ?? "-",
+  courseId: registeredCourse?.id ?? "undef",
+  attendance: registeredCourse?.attendance ?? 0,
+  absence: registeredCourse?.absence ?? 0,
+  late: registeredCourse?.late ?? 0,
+  memo: registeredCourse?.memo ?? "",
+  registeredCourse,
+});
+
+// getLectureTimeAsStr.ts
+
+// 2次元配列を転置
+const transpose = (matrix: string[][]) =>
+  matrix[0].map((_, i) => matrix.map((r) => r[i]));
+
+// 1. string[][1]の重複した要素を取り除く
+// Ex) [['月', '56'], ['火', '56']] -> [['月', ''], ['火', '56']]
+// 2. string[][]の要素を結合して文字列に変換する
+// Ex) [['月', ''], ['火', '56']] -> '月火56'
+const reduceArr = (arr: string[][]) => {
+  for (let i = 1; i < arr.length; i++) {
+    if (arr[i - 1][1] == arr[i][1]) {
+      arr[i - 1][1] = "";
+    }
+  }
+  return arr.reduce((acc, cur) => {
+    return acc + cur[0] + cur[1];
+  }, "");
+};
+
+const genTreeStrucStr = (
+  startIdx: number,
+  endIdx: number,
+  rows: string[][],
+  level: number
+): string => {
+  if (level == 4) {
+    return "";
+  }
+  const arr = rows[level];
+  const letters: string[][] = [];
+  let nextStart = startIdx;
+  for (let i = startIdx; i <= endIdx; i++) {
+    if (i == endIdx || arr[i] != arr[i + 1]) {
+      const s = genTreeStrucStr(nextStart, i, rows, level + 1);
+      if (typeof s !== "undefined") {
+        letters.push([arr[i], s]);
+      } else {
+        letters.push([arr[i], ""]);
+      }
+      nextStart = i + 1;
+    }
+  }
+  return reduceArr(letters);
+};
+
+const getLectureTimeAsStr = (schedules: CourseSchedule[]): string => {
+  if (schedules.length > 0) {
+    const li = schedules.map((x): string[] => {
+      // 0時限目は''と扱う
+      const period = x.period === 0 ? "" : String(x.period);
+      return [x.module[0], x.module[1], x.day, period];
+    });
+    const translocation = transpose(li);
+    const txt = genTreeStrucStr(
+      0,
+      translocation[0].length - 1,
+      translocation,
+      0
+    );
+    return txt;
+  } else {
+    return "";
+  }
+};

--- a/src/entities/method.ts
+++ b/src/entities/method.ts
@@ -11,9 +11,9 @@ export const methodMap: { [key in CourseMethod]: MethodJa } = {
 
 export const methodToJa = (method: CourseMethod): MethodJa => methodMap[method];
 
-export type methodOption = MethodJa | "指定なし";
+export type MethodOption = MethodJa | "指定なし";
 
-export const methodOptions: methodOption[] = [
+export const methodOptions: MethodOption[] = [
   "指定なし",
   "対面",
   "同時双方向",
@@ -21,7 +21,7 @@ export const methodOptions: methodOption[] = [
   "その他",
 ];
 
-export const createOption = (selectedOptions: { value: methodOption }[]) => {
+export const createOption = (selectedOptions: { value: MethodOption }[]) => {
   return methodOptions.filter((option) => {
     return !selectedOptions.some((obj) => obj.value === option);
   });

--- a/src/entities/schedule.ts
+++ b/src/entities/schedule.ts
@@ -4,16 +4,14 @@ export type Schedule = {
   module: string;
   day: string;
   period: string;
-  room: string;
 };
 
 const defaultValue = "指定なし";
 
 export const apiToDisplaySchedule = (api: CourseSchedule[]): Schedule[] => {
-  return api.map(({ day, module, period, room }) => ({
+  return api.map(({ day, module, period }) => ({
     day,
     module,
     period: period === 0 ? defaultValue : String(period),
-    room: room === "" ? defaultValue : room,
   }));
 };

--- a/src/entities/schedule.ts
+++ b/src/entities/schedule.ts
@@ -1,0 +1,19 @@
+import { CourseSchedule } from "~/api/@types";
+
+export type Schedule = {
+  module: string;
+  day: string;
+  period: string;
+  room: string;
+};
+
+const defaultValue = "指定なし";
+
+export const apiToDisplaySchedule = (api: CourseSchedule[]): Schedule[] => {
+  return api.map(({ day, module, period, room }) => ({
+    day,
+    module,
+    period: period === 0 ? defaultValue : String(period),
+    room: room === "" ? defaultValue : room,
+  }));
+};

--- a/src/pages/add/manual.vue
+++ b/src/pages/add/manual.vue
@@ -128,9 +128,10 @@ import Label from "~/components/Label.vue";
 import LabeledTextField from "~/components/LabeledTextField.vue";
 import Modal from "~/components/Modal.vue";
 import PageHeader from "~/components/PageHeader.vue";
-import ScheduleEditer, { Schedules } from "~/components/ScheduleEditer.vue";
+import ScheduleEditer from "~/components/ScheduleEditer.vue";
 import TextFieldSingleLine from "~/components/TextFieldSingleLine.vue";
 import { MethodJa } from "~/entities/method";
+import { Schedule } from "~/entities/schedule";
 import { useSwitch } from "~/hooks/useSwitch";
 
 export default defineComponent({
@@ -150,17 +151,18 @@ export default defineComponent({
     const router = useRouter();
 
     /** schedule-editor */
-    const schedules = ref<Schedules>([
-      { semester: "指定なし", date: "指定なし", period: "指定なし" },
+    const schedules = ref<Schedule[]>([
+      { module: "指定なし", day: "指定なし", period: "指定なし", room: "" },
     ]);
     const scheduleMax = 4;
     const scheduleMin = 1;
     const addSchedule = () => {
       if (schedules.value.length >= scheduleMax) return;
       schedules.value.push({
-        semester: "指定なし",
-        date: "指定なし",
+        module: "指定なし",
+        day: "指定なし",
         period: "指定なし",
+        room: "",
       });
     };
     const removeSchedule = (index: number) => {

--- a/src/pages/add/manual.vue
+++ b/src/pages/add/manual.vue
@@ -152,7 +152,7 @@ export default defineComponent({
 
     /** schedule-editor */
     const schedules = ref<Schedule[]>([
-      { module: "指定なし", day: "指定なし", period: "指定なし", room: "" },
+      { module: "指定なし", day: "指定なし", period: "指定なし" },
     ]);
     const scheduleMax = 4;
     const scheduleMin = 1;
@@ -162,7 +162,6 @@ export default defineComponent({
         module: "指定なし",
         day: "指定なし",
         period: "指定なし",
-        room: "",
       });
     };
     const removeSchedule = (index: number) => {

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -149,8 +149,9 @@ import CourseDetailMini from "~/components/CourseDetailMini.vue";
 import IconButton from "~/components/IconButton.vue";
 import Modal from "~/components/Modal.vue";
 import PageHeader from "~/components/PageHeader.vue";
-import ScheduleEditer, { Schedules } from "~/components/ScheduleEditer.vue";
+import ScheduleEditer from "~/components/ScheduleEditer.vue";
 import TextFieldSingleLine from "~/components/TextFieldSingleLine.vue";
+import { Schedule } from "~/entities/schedule";
 
 export default defineComponent({
   components: {
@@ -174,17 +175,18 @@ export default defineComponent({
     const [onlyBlank, toggleOnlyBlank] = useToggle();
 
     /** schedule-editor */
-    const schedules = ref<Schedules>([
-      { semester: "指定なし", date: "指定なし", period: "指定なし" },
+    const schedules = ref<Schedule[]>([
+      { module: "指定なし", day: "指定なし", period: "指定なし", room: "" },
     ]);
     const scheduleMax = 4;
     const scheduleMin = 1;
     const addSchedule = () => {
       if (schedules.value.length >= scheduleMax) return;
       schedules.value.push({
-        semester: "指定なし",
-        date: "指定なし",
+        module: "指定なし",
+        day: "指定なし",
         period: "指定なし",
+        room: "",
       });
     };
     const removeSchedule = (index: number) => {

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -176,7 +176,7 @@ export default defineComponent({
 
     /** schedule-editor */
     const schedules = ref<Schedule[]>([
-      { module: "指定なし", day: "指定なし", period: "指定なし", room: "" },
+      { module: "指定なし", day: "指定なし", period: "指定なし" },
     ]);
     const scheduleMax = 4;
     const scheduleMin = 1;
@@ -186,7 +186,6 @@ export default defineComponent({
         module: "指定なし",
         day: "指定なし",
         period: "指定なし",
-        room: "",
       });
     };
     const removeSchedule = (index: number) => {

--- a/src/pages/course/_id/edit.vue
+++ b/src/pages/course/_id/edit.vue
@@ -139,7 +139,6 @@ export default defineComponent({
       module: "指定なし",
       day: "指定なし",
       period: "指定なし",
-      room: "",
     };
     const schedules = ref<Schedule[]>(apiToDisplaySchedule(apiSchedules.value));
     const scheduleMax = 4;

--- a/src/pages/preview.vue
+++ b/src/pages/preview.vue
@@ -324,7 +324,6 @@ export default defineComponent({
         module: "指定なし",
         day: "指定なし",
         period: "指定なし",
-        room: "",
       },
     ]);
     const displayLog = () => {
@@ -408,7 +407,6 @@ export default defineComponent({
         module: "指定なし",
         day: "指定なし",
         period: "指定なし",
-        room: "",
       });
     };
     const removeScheduleRow = (index: number) => {

--- a/src/pages/preview.vue
+++ b/src/pages/preview.vue
@@ -268,13 +268,14 @@ import PopupContent, {
 } from "~/components/PopupContent.vue";
 import Modal from "~/components/Modal.vue";
 import PageHeader from "~/components/PageHeader.vue";
-import ScheduleEditer, { Schedules } from "~/components/ScheduleEditer.vue";
+import ScheduleEditer from "~/components/ScheduleEditer.vue";
 import LabeledTextField from "~/components/LabeledTextField.vue";
 import TextFieldSingleLine from "~/components/TextFieldSingleLine.vue";
 import InputButtonFile from "~/components/InputButtonFile.vue";
 import CheckContent from "~/components/CheckContent.vue";
-import { methodOption } from "~/entities/method";
+import { MethodOption } from "~/entities/method";
 import { asyncSetTimeout } from "~/usecases/asyncSetTimeout";
+import { Schedule } from "~/entities/schedule";
 
 export default defineComponent({
   name: "Preview",
@@ -318,8 +319,13 @@ export default defineComponent({
     });
     const tileStat = ref<CourseTileState>("default");
     const isCourseCheked = ref(false);
-    const schedules = ref<Schedules>([
-      { semester: "指定なし", date: "指定なし", period: "指定なし" },
+    const schedules = ref<Schedule[]>([
+      {
+        module: "指定なし",
+        day: "指定なし",
+        period: "指定なし",
+        room: "",
+      },
     ]);
     const displayLog = () => {
       console.log("click");
@@ -399,9 +405,10 @@ export default defineComponent({
 
     const addScheduleRow = () => {
       schedules.value.push({
-        semester: "指定なし",
-        date: "指定なし",
+        module: "指定なし",
+        day: "指定なし",
         period: "指定なし",
+        room: "",
       });
     };
     const removeScheduleRow = (index: number) => {
@@ -412,7 +419,7 @@ export default defineComponent({
     const inputValue = ref("");
 
     // dropdonw-addable
-    const methods = reactive<{ value: methodOption }[]>([
+    const methods = reactive<{ value: MethodOption }[]>([
       { value: "指定なし" },
     ]);
     const addMethod = () => {

--- a/src/route.ts
+++ b/src/route.ts
@@ -6,8 +6,8 @@ import Add from "./pages/add/index.vue";
 import Search from "./pages/add/search.vue";
 import CSV from "./pages/add/csv.vue";
 import Manual from "./pages/add/manual.vue";
-import Details from "./pages/course/_course_id/index.vue";
-import Edit from "./pages/course/_course_id/edit.vue";
+import Details from "./pages/course/_id/index.vue";
+import Edit from "./pages/course/_id/edit.vue";
 import Preview from "./pages/preview.vue";
 
 const history = createWebHistory();
@@ -26,8 +26,8 @@ const routes: RouteRecordRaw[] = [
   { path: "/add/search", component: Search },
   { path: "/add/csv", component: CSV },
   { path: "/add/manual", component: Manual },
-  { path: "/course/:course_id/edit", component: Edit },
-  { path: "/course/:course_id", component: Details },
+  { path: "/course/:id/edit", component: Edit },
+  { path: "/course/:id", component: Details },
   { path: "/preview", component: Preview },
 ];
 

--- a/src/store/getter.ts
+++ b/src/store/getter.ts
@@ -5,4 +5,5 @@ export const getters: GetterTree<GlobalState, GlobalState> = {
   sidebar: (state) => {
     return state.sidebar;
   },
+  courses: (state) => state.courses,
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,12 +1,13 @@
 import { InjectionKey } from "vue";
 import { createStore, Store, useStore as useStoreAny } from "vuex";
-import { User } from "~/api/@types";
+import { User, RegisteredCourse } from "~/api/@types";
 import { mutations } from "./mutations";
 import { getters } from "./getter";
 
 export type GlobalState = {
   user: User | null;
   sidebar: boolean;
+  courses: RegisteredCourse[];
 };
 
 export const StateKey: InjectionKey<Store<GlobalState>> = Symbol();
@@ -14,6 +15,7 @@ export const StateKey: InjectionKey<Store<GlobalState>> = Symbol();
 const initState: GlobalState = {
   user: null,
   sidebar: false,
+  courses: [],
 };
 
 export const store = createStore<GlobalState>({

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -1,5 +1,5 @@
 import { MutationTree } from "vuex";
-import { User } from "~/api/@types";
+import { User, RegisteredCourse } from "~/api/@types";
 import { GlobalState } from ".";
 
 export const mutations: MutationTree<GlobalState> = {
@@ -12,5 +12,8 @@ export const mutations: MutationTree<GlobalState> = {
   },
   setSidebar(state, show: boolean) {
     state.sidebar = show;
+  },
+  setCourses(state, courses: RegisteredCourse[]) {
+    state.courses = courses;
   },
 };

--- a/src/usecases/deleteRegisteredCourse.ts
+++ b/src/usecases/deleteRegisteredCourse.ts
@@ -1,0 +1,15 @@
+import { Ports } from "~/adapter";
+
+/**
+ * idに該当する登録済みの講義を削除する。
+ */
+
+export const deleteRegisteredCourse = ({ api }: Ports) => async (
+  id: string
+) => {
+  try {
+    await api.registered_courses._id(id).$delete();
+  } catch (error) {
+    return;
+  }
+};

--- a/src/usecases/getRegisteredCourse.ts
+++ b/src/usecases/getRegisteredCourse.ts
@@ -1,0 +1,44 @@
+import { CourseMethod, CourseSchedule, RegisteredCourse } from "~/api/@types";
+import { store } from "~/store";
+import { reactive, ToRefs, toRefs } from "vue-demi";
+import { apiToDisplayCourse, DisplayCourse } from "~/entities/course";
+import { Ports } from "~/adapter";
+
+/**
+ * storeまたはAPIからidに該当する講義データを取得する。
+ */
+export const getRegisteredCourse = ({ api }: Ports) => async (
+  id: string
+): Promise<RegisteredCourse> => {
+  try {
+    const storedCourse = (store.getters
+      .courses as Array<RegisteredCourse>).find((c) => id === c.id);
+    return storedCourse === undefined
+      ? await api.registered_courses._id(id).$get()
+      : storedCourse;
+  } catch (error) {
+    console.error(error);
+    throw new Error("idに該当する講義が見つかりません");
+  }
+};
+
+export const useDisplayCourse = (ports: Ports) => async (
+  id: string
+): Promise<ToRefs<DisplayCourse>> => {
+  const regiesteredCourse = await getRegisteredCourse(ports)(id);
+  const displayedCourse = apiToDisplayCourse(regiesteredCourse);
+  return toRefs(reactive(displayedCourse));
+};
+
+export const useRegisteredCourse = (ports: Ports) => async (id: string) => {
+  const regiesteredCourse = await getRegisteredCourse(ports)(id);
+  return toRefs(
+    reactive({
+      name: "",
+      instructor: "",
+      methods: [] as CourseMethod[],
+      schedules: [] as CourseSchedule[],
+      ...regiesteredCourse,
+    })
+  );
+};

--- a/src/usecases/index.ts
+++ b/src/usecases/index.ts
@@ -24,7 +24,7 @@ export const useUsecase = <T>(
   return useAsyncState(fn(ports), initState);
 };
 
-export const usePorts = () => ({
+export const usePorts = (): Ports => ({
   api: instance(
     axiosClient(axios, {
       withCredentials: true,

--- a/src/usecases/index.ts
+++ b/src/usecases/index.ts
@@ -28,7 +28,6 @@ export const usePorts = (): Ports => ({
   api: instance(
     axiosClient(axios, {
       withCredentials: true,
-      validateStatus: () => true,
     })
   ) as ApiInstance,
   store: useStore(),

--- a/src/usecases/openUrl.ts
+++ b/src/usecases/openUrl.ts
@@ -1,0 +1,9 @@
+import { isMobile } from "./ua";
+
+export const openUrl = (url: string) => {
+  if (isMobile()) {
+    location.href = url;
+  } else {
+    window.open(url);
+  }
+};

--- a/src/usecases/setRegisteredCourses.ts
+++ b/src/usecases/setRegisteredCourses.ts
@@ -1,0 +1,20 @@
+import { Ports } from "~/adapter";
+
+/**
+ * ローカルストレージまたはAPIから登録済みの講義データを取得して、storeに保存する。
+ */
+export const setRegisteredCourses = ({
+  api,
+  store,
+  now,
+}: Ports) => async (): Promise<void> => {
+  try {
+    console.log("usecase: setRegisteredCourses");
+    const registeredCourses = await api.registered_courses.$get({
+      query: { year: now.year() },
+    });
+    store.commit("setCourses", registeredCourses);
+  } catch (error) {
+    throw new Error("登録された講義を取得できませんでした。");
+  }
+};

--- a/src/usecases/ua.ts
+++ b/src/usecases/ua.ts
@@ -1,0 +1,14 @@
+/**
+ * User Agentを管理
+ */
+
+// https://github.com/twin-te/twinte-ios/blob/ce35c084c48403357689abb4a2cca662aafc4124/Twinte/ViewController.swift#L40
+export const isiOS = () =>
+  /Twin:teAppforiP(hone|ad)/.test(window.navigator.userAgent);
+
+// https://github.com/twin-te/twinte-android/blob/6088cc29a813407c503450ce5bafe4c2b54ebe33/app/src/main/java/net/twinte/android/MainActivity.kt#L39
+export const isAndroid = () =>
+  /TwinteAppforAndroid/.test(window.navigator.userAgent);
+
+export const isMobile = () => isiOS() || isAndroid();
+export const isPc = () => !isMobile();

--- a/src/usecases/updateCourse.ts
+++ b/src/usecases/updateCourse.ts
@@ -1,0 +1,19 @@
+import { RegisteredCourse } from "~/api/@types";
+import { Ports } from "~/adapter";
+
+/**
+ * 出欠カウントを更新する。
+ */
+
+export const updateCourse = ({ api }: Ports) => async (
+  course: RegisteredCourse
+): Promise<RegisteredCourse> => {
+  try {
+    const currentCourse = await api.registered_courses
+      ._id(course.id)
+      .$put({ body: course });
+    return currentCourse;
+  } catch (error) {
+    return course;
+  }
+};

--- a/src/usecases/updateRegisteredCourse.ts
+++ b/src/usecases/updateRegisteredCourse.ts
@@ -1,0 +1,37 @@
+import { RegisteredCourse, RegisteredCourseWithoutID } from "~/api/@types";
+import { store } from "~/store";
+
+/**
+ * 登録済みの講義データを新たな講義データに更新する。
+ */
+
+export const updateRegisteredCourse = async (
+  id: string,
+  newCourse: RegisteredCourseWithoutID
+): Promise<void> => {
+  console.log("usecase: updateRegisteredCourse");
+  /** API */
+  // const { status, body: currentCourse } = await api.registered_courses._id(id).put({ body: newCourse });
+  // if (status !== 200) return Promise.reject("講義の情報を更新できませんでした。");
+  // store.commit("updateCourse", currentCourse);
+  // storage.set("courses");
+  // return;
+
+  /** APIの代わり */
+  const currentCourse = {} as RegisteredCourse;
+  Object.assign(currentCourse, store.getters.course(id));
+  ["name", "instructor", "credit", "methods", "schedules"].forEach((key) => {
+    if (
+      (currentCourse.course != null &&
+        currentCourse.course[key] != newCourse[key]) ||
+      currentCourse.course == null
+    ) {
+      currentCourse[key] = newCourse[key];
+    }
+  });
+  ["memo", "attendance", "absence", "late", "tags"].forEach((key) => {
+    currentCourse[key] = newCourse[key];
+  });
+  store.commit("updateCourse", currentCourse);
+  return;
+};


### PR DESCRIPTION
## 概要
授業詳細ページの機能面の追加

## やったこと
- registered-course関連のusecase, mutation, getterの追加
- local storageの追加
- メモと出欠の自動保存

## 備考
- エラー処理の仕方が分からない。
- apiが叩けないので自力で処理をしている。
- pathのcourse_idは`~/storage`にあるcourse1などを使ってください。
- PRを出すべきかわからなかったのでとりあえず出します。