### PR TITLE
エラー処理を試験的に追加

### DIFF
--- a/src/pages/add/csv.vue
+++ b/src/pages/add/csv.vue
@@ -112,7 +112,6 @@ import IconButton from "~/components/IconButton.vue";
 import InputButtonFile from "~/components/InputButtonFile.vue";
 import Modal from "~/components/Modal.vue";
 import PageHeader from "~/components/PageHeader.vue";
-import { NetworkAccessError } from "~/usecases/error";
 
 export default defineComponent({
   name: "CSV",
@@ -165,9 +164,7 @@ export default defineComponent({
         );
         router.push("/");
       } catch (error) {
-        if (error instanceof NetworkAccessError) {
-          errorMessage.value = error.message;
-        }
+        errorMessage.value = error.message;
         isCsvValid.value = false;
         console.error(error);
       }
@@ -190,9 +187,7 @@ export default defineComponent({
           await getCoursesByCode(ports)(coursesId)
         ).map((course) => ({ course, isSelected: true }));
       } catch (error) {
-        if (error instanceof NetworkAccessError) {
-          errorMessage.value = error.message;
-        }
+        errorMessage.value = error.message;
         isCsvValid.value = false;
         console.error(error);
         return;

--- a/src/usecases/bulkAddCourseById.ts
+++ b/src/usecases/bulkAddCourseById.ts
@@ -1,6 +1,5 @@
+import { NetworkAccessError } from "~/usecases/error";
 import { Ports } from "~/adapter";
-
-// TODO: addCourseBymanualとコードが重複してるので統合する。
 
 /**
  * 講義情報をサーバに登録し、成功すれば Vuex にも登録する。
@@ -8,17 +7,19 @@ import { Ports } from "~/adapter";
 export const bulkAddCourseById = ({ api, store }: Ports) => async (
   codes: string[]
 ) => {
-  try {
-    const { body: registeredCourses } = await api.registered_courses.post({
-      body: codes.map((code) => ({
-        code,
-        year: 2020,
-      })),
-    });
-    store.commit("addCourses", registeredCourses);
-    return registeredCourses;
-  } catch (error) {
-    console.error(error);
-    throw new Error("授業の登録に失敗しました。");
+  // const { body, headers, status } = await api.registered_courses.post({
+  const { body, status, originalResponse } = await api.registered_courses.post({
+    body: codes.map((code) => ({
+      code,
+      year: 2020,
+    })),
+  });
+  store.commit("addCourses", body);
+  if (200 <= status && status < 300) {
+    return body;
+  } else {
+    console.error(body);
+    console.error(originalResponse);
+    throw new NetworkAccessError(originalResponse);
   }
 };

--- a/src/usecases/bulkAddCourseById.ts
+++ b/src/usecases/bulkAddCourseById.ts
@@ -1,4 +1,4 @@
-import { NetworkAccessError } from "~/usecases/error";
+import { NetworkError, NetworkAccessError } from "~/usecases/error";
 import { Ports } from "~/adapter";
 
 /**
@@ -7,13 +7,16 @@ import { Ports } from "~/adapter";
 export const bulkAddCourseById = ({ api, store }: Ports) => async (
   codes: string[]
 ) => {
-  // const { body, headers, status } = await api.registered_courses.post({
-  const { body, status, originalResponse } = await api.registered_courses.post({
-    body: codes.map((code) => ({
-      code,
-      year: 2020,
-    })),
-  });
+  const { body, status, originalResponse } = await api.registered_courses
+    .post({
+      body: codes.map((code) => ({
+        code,
+        year: 2020,
+      })),
+    })
+    .catch(() => {
+      throw new NetworkError();
+    });
   store.commit("addCourses", body);
   if (200 <= status && status < 300) {
     return body;

--- a/src/usecases/error.ts
+++ b/src/usecases/error.ts
@@ -1,0 +1,39 @@
+export class BaseError extends Error {
+  constructor(e?: string) {
+    super(e);
+    this.name = new.target.name;
+    /**
+     * @warn 出力ターゲットがES2015より古い場合以下が必要
+     */
+    // Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export type OriginalResponse = {
+  data: {
+    message: string;
+    errors: object[];
+  };
+  status: number;
+  statusText: string;
+  headers: any;
+};
+
+/**
+ * 300~500番台のネットワークエラー
+ */
+export class NetworkAccessError extends BaseError {
+  status: number;
+  constructor(public originalResponse: OriginalResponse, e?: string) {
+    super(e);
+    this.status = originalResponse.status;
+    this.message = originalResponse.data.message ?? "エラー";
+  }
+}
+
+// export class InvalidCsvError extends BaseError {
+//   constructor(public originalResponse: OriginalResponse, e?: string) {
+//     super(e);
+//     this.message = originalResponse.data.message;
+//   }
+// }

--- a/src/usecases/error.ts
+++ b/src/usecases/error.ts
@@ -9,6 +9,16 @@ export class BaseError extends Error {
   }
 }
 
+/**
+ * レスポンスが返ってこないときなどに使用
+ */
+export class NetworkError extends BaseError {
+  constructor(e?: string) {
+    super(e);
+    this.message = "ネットワークエラー。通信状況をご確認下さい。";
+  }
+}
+
 export type OriginalResponse = {
   data: {
     message: string;
@@ -20,7 +30,7 @@ export type OriginalResponse = {
 };
 
 /**
- * 300~500番台のネットワークエラー
+ * 2xx以外のレスポンス時に使用
  */
 export class NetworkAccessError extends BaseError {
   status: number;
@@ -30,10 +40,3 @@ export class NetworkAccessError extends BaseError {
     this.message = originalResponse.data.message ?? "エラー";
   }
 }
-
-// export class InvalidCsvError extends BaseError {
-//   constructor(public originalResponse: OriginalResponse, e?: string) {
-//     super(e);
-//     this.message = originalResponse.data.message;
-//   }
-// }

--- a/src/usecases/getCourseById.ts
+++ b/src/usecases/getCourseById.ts
@@ -5,7 +5,7 @@ import {
   RegisteredCourse,
 } from "~/api/@types";
 import { apiToDisplayCourse, DisplayCourse } from "~/entities/course";
-import { NetworkAccessError } from "./error";
+import { NetworkError, NetworkAccessError } from "~/usecases/error";
 import { Ports } from "~/adapter";
 import { reactive, ToRefs, toRefs } from "vue-demi";
 import { store } from "~/store";
@@ -28,7 +28,8 @@ export const getCourseById = ({ api }: Ports) => async (
   }
 };
 
-// TODO: 適切なファイルに移動
+// TODO: getCourseByCode.ts などの適切なファイルに移動
+// code と id を混合してました
 /**
  * APIから code に該当する講義データを取得する。
  * 一部の code が不正だった場合エラーにならずにその code を除いた正常な講義データのみが返却される
@@ -37,12 +38,16 @@ export const getCoursesByCode = ({ api }: Ports) => async (
   codes: string[]
 ): Promise<Course[]> => {
   // TODO: 年度は動的に取得する
-  const { body, status, originalResponse } = await api.courses.get({
-    query: {
-      year: 2020,
-      codes: codes.join(","),
-    },
-  });
+  const { body, status, originalResponse } = await api.courses
+    .get({
+      query: {
+        year: 2020,
+        codes: codes.join(","),
+      },
+    })
+    .catch(() => {
+      throw new NetworkError();
+    });
   if (200 <= status && status < 300) {
     return body;
   } else {

--- a/src/usecases/index.ts
+++ b/src/usecases/index.ts
@@ -33,9 +33,10 @@ export const useUsecase = <T>(
 export const usePorts = () => ({
   api: instance(
     axiosClient(axios, {
-      withCredentials: true,
-      paramsSerializer: (r) => qs.stringify(r),
       baseURL,
+      paramsSerializer: (r) => qs.stringify(r),
+      validateStatus: () => true,
+      withCredentials: true,
     })
   ) as ApiInstance,
   store: useStore(),

--- a/src/usecases/readCSV.ts
+++ b/src/usecases/readCSV.ts
@@ -10,6 +10,6 @@ export const getCoursesIdByFile = (file: File): Promise<string[]> => {
         .map((v) => v.replace(/"/g, ""));
       resolve(courses);
     };
-    reader.onerror = () => reject;
+    reader.onerror = (error) => reject(error);
   });
 };


### PR DESCRIPTION
PR の正しい使い方ではないのかもしれませんが、エラー処理を一部試験的に実装したのでご意見を頂きたいです。
merge したため履歴が見づらくなってしまったのですが[3941744](https://github.com/twin-te/twinte-front/commit/39463990424d93b712c48be96c79f25fc131909d)あたりを見てもらえるといいです。

色々迷ったのですが、エラー処理は `Error` を継承したユーザ定義のクラスを実装し、それを `throw` する形にしました。これならスタックトレースも取れますし明確にエラーを表現できるかなと思ったからです。

以下今回の実装で参考にした資料です。
- https://future-architect.github.io/typescript-guide/exception.html#id4
- https://qiita.com/shibukawa/items/ffe7264ecff78f55b296
- https://teratail.com/questions/114258

throw を使わない手法もありました。
- https://dev.classmethod.jp/articles/error-handling-practice-of-typescript/
- https://medium.com/inato/expressive-error-handling-in-typescript-and-benefits-for-domain-driven-design-70726e061c86