### PR TITLE
Add Docker for production

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,57 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/twin-te/twinte-front
+          tag-sha: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14 AS builder
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install
+
+COPY . ./
+RUN yarn build
+
+FROM nginx
+COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
本番環境でフロントエンドを serve するための Docker イメージを追加します。
イメージ自体は `yarn build` でビルドをしたファイルを nginx で serve するだけのシンプルなものです。

GitHub Actions で `main` ブランチに push されるたびにイメージをビルドします。
Public リポジトリなのでサイズ等は問題にならないはずです。

バックエンド系のリポジトリの CI とは異なる workflow になってますが、

* 数日前にリリースされた GitHub Actions のトークンで push できる機能 (https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/) を使う
* うまくキャッシュされるように https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache をベースに

書いたためです。