### PR TITLE
エラーハンドリングを追加

### DIFF
--- a/src/pages/add/manual.vue
+++ b/src/pages/add/manual.vue
@@ -221,11 +221,11 @@ export default defineComponent({
       }
       try {
         await addCourseByManual(ports)(course);
-        router.push("/");
-      } catch {
-        // TODO: エラー表示を追加
-        console.error("ERROR");
+      } catch (error) {
+        console.error(error);
+        return;
       }
+      router.push("/");
     };
 
     return {

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -206,14 +206,16 @@ export default defineComponent({
     const searchWord = ref("");
     const search = async () => {
       isAccordionOpen.value = false;
-      const courses = await searchCourse(ports)(
-        schedules.value,
-        searchWord.value.split(/\s/)
-      ).catch((e) => {
-        // TODO: エラー処理を実装
-        console.error(e);
-        return [];
-      });
+      let courses: Course[] = [];
+      try {
+        courses = await searchCourse(ports)(
+          schedules.value,
+          searchWord.value.split(/\s/)
+        );
+      } catch (error) {
+        console.error(error);
+        return;
+      }
       searchResult.value =
         courses?.map((course: Course) => ({ course, isSelected: false })) ?? [];
       isNoResultShow.value = courses.length === 0;
@@ -248,11 +250,11 @@ export default defineComponent({
             .filter((v) => v.isSelected)
             .map((v) => v.course.code)
         );
-        router.push("/");
       } catch (e) {
-        // TODO: エラー処理を実装
         console.error(e);
+        return;
       }
+      router.push("/");
     };
 
     return {

--- a/src/pages/course/_id/edit.vue
+++ b/src/pages/course/_id/edit.vue
@@ -132,7 +132,10 @@ export default defineComponent({
       methods,
       name,
       schedules: apiSchedules,
-    } = await useRegisteredCourse(ports)(id);
+    } = await useRegisteredCourse(ports)(id).catch((error) => {
+      // TODO: エラー表示処理を追加
+      throw error;
+    });
 
     /** schedule-editor */
     const blankSchedule: Schedule = {

--- a/src/pages/course/_id/index.vue
+++ b/src/pages/course/_id/index.vue
@@ -232,7 +232,13 @@ export default defineComponent({
       closeDeleteCourseModal,
     ] = useSwitch();
     const deleteCourse = async () => {
-      await apiDeleteCourse(ports)(id);
+      try {
+        await apiDeleteCourse(ports)(id);
+      } catch (error) {
+        // TODO: エラー表示を追加
+        console.error(error);
+        return;
+      }
       closeDeleteCourseModal();
       router.push("/");
     };
@@ -296,9 +302,16 @@ export default defineComponent({
       });
       // TODO: as を使わない実装
       if (!course.course) return;
-      const newCourse = await updateCourse(ports)(
-        course as Required<RegisteredCourse>
-      );
+      let newCourse: RegisteredCourse;
+      try {
+        newCourse = await updateCourse(ports)(
+          course as Required<RegisteredCourse>
+        );
+      } catch (error) {
+        // TODO: エラー表示を実装
+        console.error(error);
+        return;
+      }
       /** const newRegisteredCourse = */ apiToDisplayCourse(newCourse);
       // code.value = newRegisteredCourse.code;
       // courseId.value = newRegisteredCourse.courseId;

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -223,8 +223,14 @@ export default defineComponent({
 
     /** サブヘッダー部分 */
     const label = ref<Labels>({ left: "通常", right: "特殊" });
-    const currentModule = await getCurrentModule(ports);
-    const calendar = await getCalendar(ports);
+    const currentModule = await getCurrentModule(ports).catch((error) => {
+      // TODO: エラー表示処理を追加
+      throw error;
+    });
+    const calendar = await getCalendar(ports).catch((error) => {
+      // TODO: エラー表示処理を追加
+      throw error;
+    });
     const module = ref(currentModule);
     const isCurrentModule = computed(() => module.value === currentModule);
     const { whichSelected, onClickLabel } = useLabel(ports);
@@ -236,7 +242,12 @@ export default defineComponent({
     };
 
     /** table */
-    const storedCourses: RegisteredCourse[] = await getCourseList(ports);
+    const storedCourses: RegisteredCourse[] = await getCourseList(ports).catch(
+      (error) => {
+        // TODO: エラー表示処理を追加
+        throw error;
+      }
+    );
     const table = computed(() =>
       courseListToTable(storedCourses, module.value)
     );

--- a/src/usecases/__tests__/authCheck.test.ts
+++ b/src/usecases/__tests__/authCheck.test.ts
@@ -5,7 +5,7 @@ describe(authCheck.name, () => {
   it("when user has not logined, should return false", async () => {
     const mockPort = {
       api: {
-        users: { me: { get: () => ({ status: 401, body: null }) } },
+        users: { me: { get: async () => ({ status: 401, body: null }) } },
       } as any,
       store: { commit: () => {} } as any,
     };
@@ -19,7 +19,7 @@ describe(authCheck.name, () => {
       api: {
         users: {
           me: {
-            get: () => ({
+            get: async () => ({
               status: 200,
               body: { id: "gb11514", name: "SampleUser" } as User,
             }),

--- a/src/usecases/__tests__/periodToString.test.ts
+++ b/src/usecases/__tests__/periodToString.test.ts
@@ -1,4 +1,4 @@
-import { Course, CourseSchedule } from "~/api/@types";
+import { CourseSchedule } from "~/api/@types";
 import { periodToString } from "../periodToString";
 
 describe(`${periodToString.name} ベース`, () => {

--- a/src/usecases/addCourseByManual.ts
+++ b/src/usecases/addCourseByManual.ts
@@ -1,6 +1,8 @@
+import { isValidStatus } from "~/usecases/api";
 import { Methods } from "~/api/registered-courses/index";
-import { RegisteredCourseWithoutID } from "~/api/@types";
+import { NetworkError, NetworkAccessError } from "~/usecases/error";
 import { Ports } from "~/adapter";
+import { RegisteredCourseWithoutID } from "~/api/@types";
 
 export const adaptToApi = (
   course: RegisteredCourseWithoutID
@@ -20,14 +22,18 @@ export const adaptToApi = (
 export const addCourseByManual = ({ api, store }: Ports) => async (
   course: Methods["post"]["reqBody"]
 ) => {
-  try {
-    const { body: registeredCourse } = await api.registered_courses.post({
+  const { body, status, originalResponse } = await api.registered_courses
+    .post({
       body: course,
+    })
+    .catch(() => {
+      throw new NetworkError();
     });
-    store.commit("addCourse", registeredCourse);
-    return registeredCourse;
-  } catch (error) {
-    console.error(error);
-    throw "コースを追加できませんでした。";
+  if (isValidStatus(status)) {
+    store.commit("addCourse", body);
+    return body;
+  } else {
+    console.error(body);
+    throw new NetworkAccessError(originalResponse);
   }
 };

--- a/src/usecases/api.ts
+++ b/src/usecases/api.ts
@@ -1,0 +1,1 @@
+export const isValidStatus = (status: number) => 200 <= status && status < 300;

--- a/src/usecases/bulkAddCourseById.ts
+++ b/src/usecases/bulkAddCourseById.ts
@@ -1,3 +1,4 @@
+import { isValidStatus } from "~/usecases/api";
 import { NetworkError, NetworkAccessError } from "~/usecases/error";
 import { Ports } from "~/adapter";
 
@@ -18,11 +19,10 @@ export const bulkAddCourseById = ({ api, store }: Ports) => async (
       throw new NetworkError();
     });
   store.commit("addCourses", body);
-  if (200 <= status && status < 300) {
+  if (isValidStatus(status)) {
     return body;
   } else {
     console.error(body);
-    console.error(originalResponse);
     throw new NetworkAccessError(originalResponse);
   }
 };

--- a/src/usecases/deleteCourse.ts
+++ b/src/usecases/deleteCourse.ts
@@ -1,14 +1,21 @@
 import { Ports } from "~/adapter";
+import { isValidStatus } from "~/usecases/api";
+import { NetworkAccessError, NetworkError } from "~/usecases/error";
 
 /**
  * idに該当する登録済みの講義を削除する。
  */
-
 export const deleteCourse = ({ api, store }: Ports) => async (id: string) => {
-  try {
-    await api.registered_courses._id(id).$delete();
+  const { body, status, originalResponse } = await api.registered_courses
+    ._id(id)
+    .delete()
+    .catch(() => {
+      throw new NetworkError();
+    });
+  if (isValidStatus(status)) {
     store.commit("deleteCourse", id);
-  } catch (error) {
-    return;
+  } else {
+    console.error(body);
+    throw new NetworkAccessError(originalResponse);
   }
 };

--- a/src/usecases/error.ts
+++ b/src/usecases/error.ts
@@ -37,6 +37,7 @@ export class NetworkAccessError extends BaseError {
   constructor(public originalResponse: OriginalResponse, e?: string) {
     super(e);
     this.status = originalResponse.status;
-    this.message = originalResponse.data.message ?? "エラー";
+    this.message =
+      originalResponse.data.message ?? "サーバエラーが発生しました。";
   }
 }

--- a/src/usecases/getCourseByCode.ts
+++ b/src/usecases/getCourseByCode.ts
@@ -1,0 +1,34 @@
+import { Course } from "~/api/@types";
+import { isValidStatus } from "~/usecases/api";
+import { NetworkError, NetworkAccessError } from "~/usecases/error";
+import { Ports } from "~/adapter";
+
+/**
+ * APIから code に該当する講義データを取得する。
+ * 一部の code が不正だった場合エラーにならずにその code を除いた正常な講義データのみが返却される
+ */
+export const getCoursesByCode = ({ api }: Ports) => async (
+  codes: string[]
+): Promise<{ courses: Course[]; missingCourseCodes: string[] }> => {
+  // TODO: 年度は動的に取得する
+  const { body, status, originalResponse } = await api.courses
+    .get({
+      query: {
+        year: 2020,
+        codes: codes.join(","),
+      },
+    })
+    .catch(() => {
+      throw new NetworkError();
+    });
+  if (isValidStatus(status)) {
+    const fetchedCourseCodes = body.map((v) => v.code);
+    const missingCourseCodes = codes.filter(
+      (code) => !fetchedCourseCodes.includes(code)
+    );
+    return { courses: body, missingCourseCodes };
+  } else {
+    console.error(body);
+    throw new NetworkAccessError(originalResponse);
+  }
+};

--- a/src/usecases/getCourseList.ts
+++ b/src/usecases/getCourseList.ts
@@ -1,8 +1,10 @@
+import { isValidStatus } from "~/usecases/api";
+import { NetworkAccessError, NetworkError } from "~/usecases/error";
 import { Ports } from "~/adapter";
 import { RegisteredCourse } from "~/api/@types";
 
 /**
- * 登録されている講義を取得する
+ * 登録されている講義を取得し同時に Vuex に保存する
  */
 export const getCourseList = async ({
   api,
@@ -13,14 +15,19 @@ export const getCourseList = async ({
   if (courses.length > 0) return courses;
   const now = dayjs();
   const year = now.month() < 3 ? now.year() - 1 : now.year();
-  try {
-    const storedCourses = await api.registered_courses.$get({
+  const { body, status, originalResponse } = await api.registered_courses
+    .get({
       query: { year },
+    })
+    .catch((error) => {
+      console.error(error);
+      throw new NetworkError();
     });
-    store.commit("setCourses", storedCourses);
-    return storedCourses;
-  } catch (error) {
-    console.error(error);
-    return [];
+  if (isValidStatus(status)) {
+    store.commit("setCourses", body);
+    return body;
+  } else {
+    console.error(body);
+    throw new NetworkAccessError(originalResponse);
   }
 };

--- a/src/usecases/getCurrentModule.ts
+++ b/src/usecases/getCurrentModule.ts
@@ -1,4 +1,4 @@
-import { ModuleJa, moduleMap } from "~/entities/module";
+import { ModuleJa, moduleToJa } from "~/entities/module";
 import { NetworkAccessError, NetworkError } from "~/usecases/error";
 import { Ports } from "~/adapter";
 import { isValidStatus } from "~/usecases/api";

--- a/src/usecases/getCurrentModule.ts
+++ b/src/usecases/getCurrentModule.ts
@@ -33,14 +33,11 @@ export const getCurrentModule = async ({
     );
   });
   switch (info?.module) {
-    case undefined:
-      return "春A";
     case "SummerVacation":
       return "春C";
     case "SpringVacation":
       return "秋C";
     default:
-      // TODO: もっといい方法があるはず
-      return info !== undefined ? moduleMap[info.module] ?? "春A" : "春A";
+      return moduleToJa(info?.module ?? "SpringA");
   }
 };

--- a/src/usecases/getCurrentModule.ts
+++ b/src/usecases/getCurrentModule.ts
@@ -1,5 +1,7 @@
-import { Ports } from "~/adapter";
 import { ModuleJa, moduleMap } from "~/entities/module";
+import { NetworkAccessError, NetworkError } from "~/usecases/error";
+import { Ports } from "~/adapter";
+import { isValidStatus } from "~/usecases/api";
 
 /**
  * 現在の学期を取得する
@@ -8,33 +10,37 @@ export const getCurrentModule = async ({
   api,
   dayjs,
 }: Ports): Promise<ModuleJa> => {
-  try {
-    const now = dayjs();
-    const year = now.month() < 3 ? now.year() - 1 : now.year();
-    const moduleInfoList = await api.school_calendar.modules.$get({
+  const now = dayjs();
+  const year = now.month() < 3 ? now.year() - 1 : now.year();
+  const { body, status, originalResponse } = await api.school_calendar.modules
+    .get({
       query: { year },
+    })
+    .catch((error) => {
+      console.error(error);
+      throw new NetworkError();
     });
-    const info = moduleInfoList.find((info) => {
-      const start = dayjs(info.start);
-      const end = dayjs(info.end);
-      return (
-        (start.isBefore(now) || start.isSame(now)) &&
-        (end.isAfter(now) || end.isSame(now))
-      );
-    });
-    switch (info?.module) {
-      case undefined:
-        return "春A";
-      case "SummerVacation":
-        return "春C";
-      case "SpringVacation":
-        return "秋C";
-      default:
-        // TODO: もっといい方法があるはず
-        return info !== undefined ? moduleMap[info.module] ?? "春A" : "春A";
-    }
-  } catch (error) {
-    console.error(error);
-    return "春A";
+  if (!isValidStatus(status)) {
+    console.error(body);
+    throw new NetworkAccessError(originalResponse);
+  }
+  const info = body.find((info) => {
+    const start = dayjs(info.start);
+    const end = dayjs(info.end);
+    return (
+      (start.isBefore(now) || start.isSame(now)) &&
+      (end.isAfter(now) || end.isSame(now))
+    );
+  });
+  switch (info?.module) {
+    case undefined:
+      return "春A";
+    case "SummerVacation":
+      return "春C";
+    case "SpringVacation":
+      return "秋C";
+    default:
+      // TODO: もっといい方法があるはず
+      return info !== undefined ? moduleMap[info.module] ?? "春A" : "春A";
   }
 };

--- a/src/usecases/searchCourse.ts
+++ b/src/usecases/searchCourse.ts
@@ -7,6 +7,8 @@ import {
 import { CourseModule, Day, SearchCourseTimetableQuery } from "~/api/@types";
 import { fullDays } from "~/entities/day";
 import { fullModules } from "~/entities/module";
+import { isValidStatus } from "~/usecases/api";
+import { NetworkAccessError, NetworkError } from "~/usecases/error";
 import { periods } from "~/entities/period";
 import { Ports } from "~/adapter";
 import { Schedule } from "~/entities/schedule";
@@ -72,18 +74,22 @@ export const searchCourse = ({ api }: Ports) => async (
   searchWords: string[]
 ) => {
   console.log(searchWords);
-  try {
-    const courses = await api.courses.search.$post({
+  const { body, status, originalResponse } = await api.courses.search
+    .post({
       body: {
         year: 2020,
         searchMode: "Cover", // TODO: ユーザが選択できるようにする
         keywords: searchWords,
         timetable: schedulesToTimetable(schedules.map(parseSchedules)),
       },
+    })
+    .catch(() => {
+      throw new NetworkError();
     });
-    return courses;
-  } catch (error) {
-    console.error(error);
-    return [];
+  if (isValidStatus(status)) {
+    return body;
+  } else {
+    console.error(body);
+    throw new NetworkAccessError(originalResponse);
   }
 };

--- a/src/usecases/updateCourse.ts
+++ b/src/usecases/updateCourse.ts
@@ -1,19 +1,24 @@
-import { RegisteredCourse } from "~/api/@types";
+import { isValidStatus } from "~/usecases/api";
+import { NetworkAccessError, NetworkError } from "~/usecases/error";
 import { Ports } from "~/adapter";
+import { RegisteredCourse } from "~/api/@types";
 
 /**
  * 出欠カウントを更新する。
  */
-
 export const updateCourse = ({ api }: Ports) => async (
   course: Required<RegisteredCourse>
 ): Promise<RegisteredCourse> => {
-  try {
-    const currentCourse = await api.registered_courses
-      ._id(course.id)
-      .$put({ body: course });
-    return currentCourse;
-  } catch (error) {
-    return course;
+  const { body, status, originalResponse } = await api.registered_courses
+    ._id(course.id)
+    .put({ body: course })
+    .catch(() => {
+      throw new NetworkError();
+    });
+  if (isValidStatus(status)) {
+    return body;
+  } else {
+    console.error(body);
+    throw new NetworkAccessError(originalResponse);
   }
 };


### PR DESCRIPTION
api 関係にエラーハンドリングを追加しました。この PR では適切なエラーインスタンスの `throw` と `catch` までを実装し、エラーの表示に関しては実装してません。したがって現段階では `setup()` の直下で起きたエラーによりコンポーネントが真っ白になったりします。現在のモジュールを取得できなかった場合などです。 エラーが起きた場合の表示方法について決まり次第別のPRで実装します。

api のエラーハンドリングは似ているロジックが多いのでもっとまとめれそうですが、とりあえず今はこれで PR させてもらいますm(_ _)m （`aspida` でエラー時の型がなかったり `status` の型が `200` に設定されていることを考えると、`axios.interceptors.response.use`などを利用するのがいいのかなと思ってたりもします。）


