### PR TITLE
Fix style bug on safari

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -153,7 +153,6 @@ export default defineComponent({
       font-size: 100%;
       line-height: $fit;
       @include text-liner;
-      @include iconlayout;
     }
   }
   &.--active,

--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -91,7 +91,6 @@ export default defineComponent({
   background: $base;
   /* shadow-convex */
   border-radius: $radius-button;
-  font-weight: medium;
   vertical-align: middle;
   transition: $transition-box-shadow;
 

--- a/src/components/CourseDetailMini.vue
+++ b/src/components/CourseDetailMini.vue
@@ -33,7 +33,6 @@ export default defineComponent({
     @include text-main;
     @include text-liner;
     @include icon-cursor;
-    @include iconlayout;
     margin-right: $spacing-1;
   }
   &__value {

--- a/src/components/IconButton.vue
+++ b/src/components/IconButton.vue
@@ -30,7 +30,7 @@ export default defineComponent({
       type: String,
       default: "normal",
       varidator: function (value: string) {
-        return ["normal", "danger"].includes(value);
+        return ["normal", "danger", "primary"].includes(value);
       },
     },
     iconName: {
@@ -113,6 +113,20 @@ export default defineComponent({
     &:active {
       color: $white;
       @include button-active-danger;
+    }
+  }
+  &--primary {
+    span {
+      @include text-liner;
+      transition: $transition-box-shadow;
+    }
+    &:active {
+      @include button-active;
+      color: $white;
+      span {
+        @include void-text-liner;
+        color: $white;
+      }
     }
   }
 }

--- a/src/components/InputButtonFile.vue
+++ b/src/components/InputButtonFile.vue
@@ -109,7 +109,6 @@ export default defineComponent({
     color: $button-gray;
 
     border-radius: $radius-button;
-    font-weight: medium;
     vertical-align: middle;
     transition: $transition-box-shadow;
     white-space: nowrap;

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -95,6 +95,7 @@ export default defineComponent({
   &__button {
     display: flex;
     flex-direction: row;
+    flex-shrink: 0;
     margin-top: $spacing-7;
   }
   &__close-btn {

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -106,7 +106,6 @@ export default defineComponent({
     font-weight: bold;
   }
   &__schedule {
-    font-weight: regular;
     padding-top: 0.2rem;
     color: $text-sub;
     font-size: $font-small;

--- a/src/components/PopupContent.vue
+++ b/src/components/PopupContent.vue
@@ -54,7 +54,7 @@ export default defineComponent({
   height: 3.8rem;
   padding: $spacing-2 3.4rem $spacing-2 $spacing-4;
   font-size: $font-large;
-  font-weight: 500;
+  font-weight: medium;
   line-height: $single-line;
   transition: $transition-box-shadow;
   @include button-cursor;

--- a/src/components/PopupContent.vue
+++ b/src/components/PopupContent.vue
@@ -54,7 +54,6 @@ export default defineComponent({
   height: 3.8rem;
   padding: $spacing-2 3.4rem $spacing-2 $spacing-4;
   font-size: $font-large;
-  font-weight: medium;
   line-height: $single-line;
   transition: $transition-box-shadow;
   @include button-cursor;

--- a/src/components/ScheduleEditer.vue
+++ b/src/components/ScheduleEditer.vue
@@ -99,7 +99,9 @@ export default defineComponent({
     }
   }
   &__container {
-    display: flex;
+    display: grid;
+    grid-auto-flow: row;
+    grid-template-columns: repeat(3, 1fr);
     width: 30rem;
     gap: $spacing-2;
   }

--- a/src/components/SidebarContent.vue
+++ b/src/components/SidebarContent.vue
@@ -61,6 +61,7 @@ export default defineComponent({
 <style scoped lang="scss">
 @import "../scss/main.scss";
 .sidebar {
+  $self: &;
   &__content {
     @include button-cursor;
     display: flex;
@@ -71,7 +72,12 @@ export default defineComponent({
     transition: $transition-box-shadow;
     color: $button-gray;
     &--selected {
-      @include text-liner;
+      #{ $self }__icon {
+        @include text-liner;
+      }
+      #{ $self }__name {
+        @include text-liner;
+      }
     }
     &:active {
       box-shadow: $shadow-concave;
@@ -84,18 +90,15 @@ export default defineComponent({
   &__icon {
     font-size: 2.8rem;
     line-height: $single-line;
-    @include iconlayout;
   }
   &__name {
     font-weight: medium;
     vertical-align: bottom;
     margin-left: $spacing-4;
     font-size: $font-medium;
-
     &--link {
       &::after {
         font-family: "Material Icons";
-        @include iconlayout;
         @include text-liner;
         content: "launch";
         padding-left: $spacing-2;

--- a/src/components/SidebarContent.vue
+++ b/src/components/SidebarContent.vue
@@ -92,7 +92,6 @@ export default defineComponent({
     line-height: $single-line;
   }
   &__name {
-    font-weight: medium;
     vertical-align: bottom;
     margin-left: $spacing-4;
     font-size: $font-medium;

--- a/src/pages/course/_id/index.vue
+++ b/src/pages/course/_id/index.vue
@@ -67,7 +67,7 @@
               class="attendance__minus-btn"
               @click="updateCounter('attendance', -1)"
               size="small"
-              color="normal"
+              color="primary"
               iconName="remove"
             ></IconButton>
             <p class="attendance__count">{{ attendance }}</p>
@@ -75,7 +75,7 @@
               class="attendance__plus-btn"
               @click="updateCounter('attendance', 1)"
               size="small"
-              color="normal"
+              color="primary"
               iconName="add"
             ></IconButton>
           </div>
@@ -85,7 +85,7 @@
               class="attendance__minus-btn"
               @click="updateCounter('absence', -1)"
               size="small"
-              color="normal"
+              color="primary"
               iconName="remove"
             ></IconButton>
             <p class="attendance__count">{{ absence }}</p>
@@ -93,7 +93,7 @@
               class="attendance__plus-btn"
               @click="updateCounter('absence', 1)"
               size="small"
-              color="normal"
+              color="primary"
               iconName="add"
             ></IconButton>
           </div>
@@ -103,7 +103,7 @@
               class="attendance__minus-btn"
               @click="updateCounter('late', -1)"
               size="small"
-              color="normal"
+              color="primary"
               iconName="remove"
             ></IconButton>
             <p class="attendance__count">{{ late }}</p>
@@ -111,7 +111,7 @@
               class="attendance__plus-btn"
               @click="updateCounter('late', 1)"
               size="small"
-              color="normal"
+              color="primary"
               iconName="add"
             ></IconButton>
           </div>
@@ -413,12 +413,6 @@ export default defineComponent({
     }
     &__plus-btn {
       grid-area: plus-btn;
-      @include text-liner;
-      &:active {
-        color: $white;
-        background: $primary-liner;
-        @include void-text-liner;
-      }
     }
     &__count {
       grid-area: count;
@@ -428,12 +422,6 @@ export default defineComponent({
     }
     &__minus-btn {
       grid-area: minus-btn;
-      @include text-liner;
-      &:active {
-        color: $white;
-        background: $primary-liner;
-        @include void-text-liner;
-      }
     }
   }
 }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -346,7 +346,7 @@ export default defineComponent({
 
   &__module-text {
     color: $text-main;
-    font-weight: $font-medium;
+    font-weight: 500;
     font-size: $font-large;
     margin: auto 0.6rem auto;
   }

--- a/src/scss/_mixin.scss
+++ b/src/scss/_mixin.scss
@@ -42,8 +42,14 @@
 @mixin text-liner {
   color: #6bcedc; // baakground-clip に対応していない場合の色
   background: $primary-liner;
+  background: -webkit-#{$primary-liner};
+  background: -moz-#{$primary-liner};
+  background-clip: text;
+  -moz-background-clip: text;
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  text-fill-color: rgba(255, 255, 255, 0);
+  -webkit-text-fill-color: rgba(255, 255, 255, 0);
+  -moz-text-fill-color: rgba(255, 255, 255, 0);
 }
 @mixin void-text-liner {
   background-clip: none;
@@ -141,10 +147,6 @@
   align-items: center;
   justify-content: center;
   flex-direction: $direction;
-}
-@mixin iconlayout {
-  display: inline-flex;
-  vertical-align: middle;
 }
 
 @mixin sensor-housing {

--- a/src/scss/_mixin.scss
+++ b/src/scss/_mixin.scss
@@ -3,7 +3,7 @@
   color: $text-main;
   font-size: $font-medium;
   line-height: $single-line;
-  font-weight: medium;
+  font-weight: 500;
 }
 @mixin text-description {
   color: $text-main;
@@ -12,20 +12,18 @@
 }
 @mixin text-button {
   color: $button-gray;
-  font-weight: medium;
+  font-weight: 400;
   line-height: $fit;
 }
 @mixin text-discription {
   color: $text-main;
   font-size: $font-medium;
   line-height: $multi-line;
-  font-weight: regular;
 }
 @mixin text-sub-discription {
   color: $text-sub;
   font-size: $font-small;
   line-height: $multi-line;
-  font-weight: regular;
 }
 @mixin modal-title {
   font-size: 2rem;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -20,7 +20,6 @@ body {
 }
 .material-icons {
   font-family: Material Icons;
-  @include iconlayout;
 }
 .preview {
   padding: $spacing-10;


### PR DESCRIPTION
resolve #265 

| |after|before|
|---|---|---|
|1. カレント表示が見えない| <img width="286" alt="スクリーンショット 2021-03-30 17 57 58" src="https://user-images.githubusercontent.com/48097323/112974045-f8c45f00-918c-11eb-93c2-04384ad27568.png">|<img width="397" alt="スクリーンショット 2021-03-14 0 53 26" src="https://user-images.githubusercontent.com/48097323/111896627-5c98aa80-8a5e-11eb-8192-f0cfa98ce177.png">|
|2. アイコンがなくdropshadowのみ|<img width="119" alt="スクリーンショット 2021-03-30 17 58 12" src="https://user-images.githubusercontent.com/48097323/112973310-23fa7e80-918c-11eb-870a-af725a2a6f25.png">|<img width="119" alt="スクリーンショット 2021-03-14 0 53 56" src="https://user-images.githubusercontent.com/48097323/111896432-ef384a00-8a5c-11eb-955b-dfff4cecec0f.png"> |
|3. モーダル下部のButtonが潰れている|<img width="544" alt="スクリーンショット 2021-03-30 17 59 31" src="https://user-images.githubusercontent.com/48097323/112973450-4db3a580-918c-11eb-9a3e-215f85a53f3f.png">|<img width="544" alt="スクリーンショット 2021-03-14 0 53 01" src="https://user-images.githubusercontent.com/48097323/111896464-260e6000-8a5d-11eb-93b1-c3c11e9ef9a6.png">|
|4. Dropdown間のmarginが消えている| <img width="379" alt="スクリーンショット 2021-03-30 19 18 09" src="https://user-images.githubusercontent.com/48097323/112973838-b3a02d00-918c-11eb-83fa-584c2093d579.png">|<img width="379" alt="スクリーンショット 2021-03-14 1 01 49" src="https://user-images.githubusercontent.com/48097323/111896484-463e1f00-8a5d-11eb-9fc8-3ca55024632f.png">|