### PR TITLE
授業追加時におこるバグを修正

### DIFF
--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -124,7 +124,7 @@
           >キャンセル</Button
         >
         <Button
-          @click="addCourse(true)"
+          @click="addCourse(false)"
           size="medium"
           layout="fill"
           color="primary"

--- a/src/usecases/bulkAddCourseById.ts
+++ b/src/usecases/bulkAddCourseById.ts
@@ -1,4 +1,3 @@
-import { RegisteredCourse } from "~/api/@types";
 import { isValidStatus } from "~/usecases/api";
 import { NetworkError, NetworkAccessError } from "~/usecases/error";
 import { Ports } from "~/adapter";
@@ -20,13 +19,10 @@ export const bulkAddCourseById = (ports: Ports) => async (codes: string[]) => {
     .catch(() => {
       throw new NetworkError();
     });
-  // bodyの型ごとに条件分岐
-  if (codes.length === 1) {
-    store.commit("addCourse", body);
+  if (Array.isArray(body)) {
+    body.map((course) => store.commit("addCourse", course));
   } else {
-    (body as RegisteredCourse[]).map((course) =>
-      store.commit("addCourse", course)
-    );
+    store.commit("addCourse", body);
   }
   if (isValidStatus(status)) {
     return body;


### PR DESCRIPTION
以下の２つのバグを修正しました。

- モーダルで授業が追加できない
- 授業追加後にエラーが発生する
授業を追加後に`Cannot read property 'filter' of undefined`が発生し、リロードするというエラーが発生しました。原因は `await api.registered_courses.post` で一つの授業を追加した場合でも配列としてかえってくることでした。
（しかし原因不明なのが、Vuex の `store.commit("addCourse", body)`で誤って配列を追加しているのに、リロードすると Vuex は正常にオブジェクトを`.push`しているんですよね。）