### PR TITLE
Fix Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ WORKDIR /app
 COPY package.json yarn.lock ./
 RUN yarn install
 
+ENV VITE_API_URL=https://app.twinte.net/api/v3
+
 COPY . ./
 RUN yarn build
 
 FROM nginx
+COPY production_nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/production_nginx.conf
+++ b/production_nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
本番用 Docker イメージで

* 開発用 API サーバーを向いている問題
* `/` 以外のページを開くと 404 になってしまう問題

を修正しました。