### PR TITLE
getYear が 2021 を返すように修正

### DIFF
--- a/src/usecases/getYear.ts
+++ b/src/usecases/getYear.ts
@@ -2,6 +2,7 @@ import { Ports } from "~/adapter";
 
 export const getYear = async ({ dayjs, api }: Ports) => {
   const now = dayjs();
-  const timeTable = await api.timetable._date(now.format("YYYY-MM-DD")).$get();
-  return timeTable.module?.year ?? 2021;
+  // const timeTable = await api.timetable._date(now.format("YYYY-MM-DD")).$get();
+  // return timeTable.module?.year ?? 2021;
+  return now.month() < 3 ? now.year() - 1 : now.year();
 };


### PR DESCRIPTION
04/02 現在 `getYear()` が  2020 を返していたので 2021 を返すように修正しました。04/02 の時点では春休みなのでバックエンドは  `year=2020` を返していることが要因です。そこで応急的に `now.month() < 3 ? now.year() - 1 : now.year()` という処理に変更しました。