### PR TITLE
Add workflow to deploy production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment'
+        required: true
+        default: 'production'
+
+defaults:
+  run:
+    working-directory: ./kustomize
+
+jobs:
+  build:
+    if: ${{ github.ref == 'refs/heads/main' && github.event.inputs.environment == 'production' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Kustomize
+      run: |
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+
+    - name: Login to Kubernetes
+      run: |
+        mkdir -p ~/.kube
+        echo "$KUBE_CONFIG" > ~/.kube/config
+      env:
+        KUBE_CONFIG: "${{secrets.KUBE_CONFIG}}"
+
+    - name: Deploy
+      run: |
+        ./kustomize edit set image ghcr.io/twin-te/twinte-front:main=ghcr.io/twin-te/twinte-front:sha-${GITHUB_SHA::7}
+        ./kustomize build . | kubectl apply -f -
+        kubectl rollout status deploy/front

--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: front
+  labels:
+    app.kubernetes.io/name: front
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: front
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: front
+    spec:
+      containers:
+      - name: nginx
+        image: ghcr.io/twin-te/twinte-front:main
+        ports:
+        - name: http
+          containerPort: 80
+        readinessProbe:
+          httpGet:
+            port: 80

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- deployment.yaml
+- service.yaml

--- a/kustomize/service.yaml
+++ b/kustomize/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: front
+  labels:
+    app.kubernetes.io/name: front
+spec:
+  selector:
+    app.kubernetes.io/name: front
+  ports:
+  - name: http
+    port: 80


### PR DESCRIPTION
本番環境へデプロイするための GitHub Actions workflow と、本番 Kubernetes 環境の定義ファイルを追加します。

これを使えば GitHub の Actions タブからこの workflow を実行することで、その時の main ブランチ最新コミットを本番環境へデプロイできるようになります。
実行時に Environment を指定できるようになっており、将来的にはここに production 以外の環境も追加できるようにする予定です。現時点では production 以外が指定された場合には何も実行されないようになっています。

本番環境にデプロイするために `KUBE_CONFIG` Secret の登録が必要ですが、自分はこのリポジトリにそれを設定する権限がないので権限を頂きたいです。