### PR TITLE
カスタム講義で出欠とメモが保存できないバグを修正

### DIFF
--- a/src/pages/course/_id/index.vue
+++ b/src/pages/course/_id/index.vue
@@ -304,7 +304,6 @@ export default defineComponent({
         registeredCourse: registeredCourse.value,
       });
       // TODO: as を使わない実装
-      if (!course.course) return;
       try {
         await updateCourse(ports)(course as Required<RegisteredCourse>);
       } catch (error) {


### PR DESCRIPTION
カスタム講義で出欠とメモを保存できるようになりました。