### PR TITLE
画面サイズによってサイドバーにアクセスできない問題を修正

### DIFF
--- a/src/scss/_mixin.scss
+++ b/src/scss/_mixin.scss
@@ -118,8 +118,10 @@
 //  Sidebar直下のページで使う。横向きレイアウトの時にヘッダーの左のボタンを表示しない。
 @mixin header-left-button-delete {
   .header__left-button-icon {
-    @include landscape {
-      display: none;
+    @include tab-and-pc {
+      @include landscape {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
原因は `.sidebar--close` と `header-left-button-delete` の media queary が一致してないことでした。

#fix 314