### PR TITLE
検索で schedule が指定されなかった場合 undefined を返すように修正

### DIFF
--- a/src/usecases/searchCourse.ts
+++ b/src/usecases/searchCourse.ts
@@ -60,7 +60,7 @@ const schedulesToTimetable = (
   onlyBlank: boolean,
   ports: Ports
 ): SearchCourseTimetableQuery | undefined => {
-  let countFalse = 0;
+  let allTrue = true;
   const timetable: Partial<SearchCourseTimetableQuery> = {};
   for (const module of fullModules) {
     timetable[module] = {};
@@ -73,11 +73,13 @@ const schedulesToTimetable = (
           ? !isSchedulesDuplicated(ports)([{ module, day, period, room: "" }])
           : isWishinSchedules(schedules, module, day, period);
         timetable[module][day][period] = ret;
-        if (ret === false) countFalse++;
+        if (ret === false) allTrue = false;
       }
     }
   }
-  return countFalse > 0 ? (timetable as SearchCourseTimetableQuery) : undefined;
+  return allTrue === true
+    ? undefined
+    : (timetable as SearchCourseTimetableQuery);
 };
 
 export const searchCourse = (ports: Ports) => async (

--- a/src/usecases/searchCourse.ts
+++ b/src/usecases/searchCourse.ts
@@ -59,7 +59,8 @@ const schedulesToTimetable = (
   schedules: ParsedSchedule[],
   onlyBlank: boolean,
   ports: Ports
-): SearchCourseTimetableQuery => {
+): SearchCourseTimetableQuery | undefined => {
+  let countFalse = 0;
   const timetable: Partial<SearchCourseTimetableQuery> = {};
   for (const module of fullModules) {
     timetable[module] = {};
@@ -67,13 +68,16 @@ const schedulesToTimetable = (
       timetable[module][day] = {};
       for (const period of [0, ...periods]) {
         // とりあえず空白検索とドロップダウン検索は or で実装
-        timetable[module][day][period] = onlyBlank
+        // HACK: backend の要望により timetable が全て true の場合 undedined を返す。
+        const ret = onlyBlank
           ? !isSchedulesDuplicated(ports)([{ module, day, period, room: "" }])
           : isWishinSchedules(schedules, module, day, period);
+        timetable[module][day][period] = ret;
+        if (ret === false) countFalse++;
       }
     }
   }
-  return timetable as SearchCourseTimetableQuery;
+  return countFalse > 0 ? (timetable as SearchCourseTimetableQuery) : undefined;
 };
 
 export const searchCourse = (ports: Ports) => async (


### PR DESCRIPTION
バックエンドより schedule が全て指定なしのとき、undefind にする処理をバグが治るまで一時的に実装してほしいと言われたのでしました。

手元でいくつかデバッグをしてみてうまく判定できています。