### PR TITLE
重複した教室を表示しないように修正

### DIFF
--- a/src/entities/courseCard.ts
+++ b/src/entities/courseCard.ts
@@ -14,7 +14,8 @@ export type CourseCard = {
  * roomを文字形式(ex 6A203, オンライン)に変換する関数
  */
 export const locationToString = (_schedules: CourseSchedule[]) => {
-  return _schedules.map((schedule) => schedule.room).join("");
+  const rooms = new Set(_schedules.map((schedule) => schedule.room));
+  return [...rooms].join(", ");
 };
 
 export const getSyllbusUrl = (code: string) => {


### PR DESCRIPTION
実は #317 に同じ教室が表示されるというバグがありました。
これは `CourseSchedule[]` の `CourseSchedule.room` に同じ値が入っていた場合も結合していたからです。
![image](https://user-images.githubusercontent.com/45098934/113472313-61694f80-949d-11eb-9200-672c14b67e0e.png)

これを重複排除して、同じ教室が表示されないように修正しました。
![image](https://user-images.githubusercontent.com/45098934/113472317-65956d00-949d-11eb-820c-cdc5f0b9ff73.png)
