### PR TITLE
テーブル内の文字が折り返されないバグと修正

### DIFF
--- a/src/components/CourseTile.vue
+++ b/src/components/CourseTile.vue
@@ -83,7 +83,7 @@ export default defineComponent({
   border-radius: $radius-1;
   text-align: left;
   transition: $transition-box-shadow;
-  overflow-y: scroll;
+  overflow: hidden;
   &.--default {
     background-color: $primary-light;
     &:active {
@@ -111,7 +111,10 @@ export default defineComponent({
   }
   &__course-room {
     @include text-course-tile-id;
-    overflow-wrap: anywhere;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 100%;
+    text-overflow: ellipsis;
   }
   &__caution {
     position: absolute;

--- a/src/components/CourseTile.vue
+++ b/src/components/CourseTile.vue
@@ -83,6 +83,7 @@ export default defineComponent({
   border-radius: $radius-1;
   text-align: left;
   transition: $transition-box-shadow;
+  overflow-y: scroll;
   &.--default {
     background-color: $primary-light;
     &:active {
@@ -110,6 +111,7 @@ export default defineComponent({
   }
   &__course-room {
     @include text-course-tile-id;
+    overflow-wrap: anywhere;
   }
   &__caution {
     position: absolute;

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -398,6 +398,7 @@ export default defineComponent({
   grid-template-columns: 2rem repeat(5, 1fr);
   grid-auto-flow: column;
   gap: 0.2rem;
+  overflow-y: auto;
 
   &__period {
     color: $text-sub;


### PR DESCRIPTION
横にはみ出た時は折り返し、縦にはみ出た時はスクロールするようにしました。
gridないで`overflow-y: scroll;`を適用するには親要素に`overflow-y: auto;`を指定する必要があるそうです。
https://stackoverflow.com/questions/49362459/vertical-scroll-bar-in-div-which-is-a-child-of-css-grid-column/49362584
<img width="403" alt="スクリーンショット 2021-04-03 20 32 37" 
src="https://user-images.githubusercontent.com/68944024/113477463-cc764e80-94bc-11eb-942a-f3ab75662f0e.png">
