### PR TITLE
fix 画面サイズによってはサイドバーにアクセスできない問題

### DIFF
--- a/src/scss/_mixin.scss
+++ b/src/scss/_mixin.scss
@@ -118,10 +118,8 @@
 //  Sidebar直下のページで使う。横向きレイアウトの時にヘッダーの左のボタンを表示しない。
 @mixin header-left-button-delete {
   .header__left-button-icon {
-    @include tab-and-pc {
-      @include landscape {
-        display: none;
-      }
+    @include landscape {
+      display: none;
     }
   }
 }

--- a/src/scss/_mixin.scss
+++ b/src/scss/_mixin.scss
@@ -170,7 +170,7 @@
 }
 
 @mixin landscape {
-  @media screen and (orientation: landscape) {
+  @media screen and (min-width: 678px) and(orientation: landscape) {
     // 画面が横向きの場合
     @content;
   }

--- a/src/templates/Layout.vue
+++ b/src/templates/Layout.vue
@@ -154,17 +154,13 @@ export default defineComponent({
   z-index: 13;
   position: fixed;
   transition: $transition-all;
-  @include tab-and-pc {
-    @include landscape {
-      position: relative;
-    }
+  @include landscape {
+    position: relative;
   }
   &--close {
     transform: translateX(-23rem);
-    @include tab-and-pc {
-      @include landscape {
-        transform: translateX(0rem);
-      }
+    @include landscape {
+      transform: translateX(0rem);
     }
   }
 }


### PR DESCRIPTION
「スマホなどの画面の小さな端末では横向き禁止」という前提のもと、サイドバーの表示の問題を改善しました。
#314 