### PR TITLE
source map を出力するように設定

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,4 @@
+# for localhost
+
+NODE_ENV=development
+VITE_API_URL=https://app.dev.twinte.net/api/v3

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,4 @@
+# for app.twinte.net
+
+NODE_ENV=production
+VITE_API_URL=https://app.twinte.net/api/v3

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,4 @@
+# for app.dev.twinte.net
+
+NODE_ENV=development
+VITE_API_URL=https://app.dev.twinte.net/api/v3

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "type-check": "vuedx-typecheck .",
     "build": "vite build",
+    "build:staging": "vite build --mode staging",
     "lint": "vuedx-typecheck . && eslint --ext .vue ./src",
     "lint:fix": "yarn lint --fix",
     "format": "prettier ./src",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,11 +2,20 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import path from "path";
 
-export default defineConfig({
+const sourcemap = {
+  development: "inline",
+  staging: "inline",
+  production: true,
+};
+
+export default defineConfig(({ mode }) => ({
   plugins: [vue()],
   resolve: {
     alias: {
       "~": path.resolve(__dirname, "src"),
     },
   },
-});
+  build: {
+    sourcemap: sourcemap[mode],
+  },
+}));


### PR DESCRIPTION
source map を出力するように設定しました。
#306 より

- デバッグ時、フィードバック時に Source map がほしい
- OSS なのでソースコードを隠す必要がない
- LightHouse で調べたところ `production mode` では sourse map を出力してもパフォーマンススコアが２点しかかわらない

との理由で source map を出力することにしました。設定の意味は、それぞれ

- development: `yarn dev` で発動。おもにローカル開発環境など。
- staging: `yarn build --mode staging` で発動。 `app.dev` で使われる。
- production: `yarn build` で発動。 `app` で使われる。

となっております。

Fix: #306 