### PR TITLE
空いているコマ検索のときはドロップダウンは非表示に

### DIFF
--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -50,7 +50,7 @@
               ></Checkbox>
               空いているコマのみを検索
             </div>
-            <div class="accordion__shedule-editor">
+            <div v-if="!onlyBlank" class="accordion__shedule-editor">
               <ScheduleEditer
                 v-model:schedules="schedules"
                 :onClickAddButton="addSchedule"
@@ -358,6 +358,7 @@ export default defineComponent({
     border-radius: $radius-1;
   }
   &__only-blank {
+    @include button-cursor;
     display: flex;
     align-items: center;
     margin-bottom: $spacing-6;


### PR DESCRIPTION
UI を決定するまではとりあえず 空きコマ検索 と ドロップダウン検索 は排他的にしようということになったので実装しました。

![image](https://user-images.githubusercontent.com/45098934/113498993-10b12f80-954d-11eb-8588-11458c1190c2.png)
![image](https://user-images.githubusercontent.com/45098934/113499012-39d1c000-954d-11eb-9979-b1ae15972d6a.png)


fix #355 