### PR TITLE
fix display area with notch

### DIFF
--- a/src/components/GrayFilter.vue
+++ b/src/components/GrayFilter.vue
@@ -22,7 +22,7 @@ export default defineComponent({
 
 .grayfilter {
   width: 100%;
-  height: 100%;
+  height: calc(100% - #{$safe-area-top});
   position: fixed;
   top: 0;
   left: 0;

--- a/src/pages/add/csv.vue
+++ b/src/pages/add/csv.vue
@@ -234,9 +234,9 @@ export default defineComponent({
   }
   &__error {
     margin-top: $spacing-6;
-    height: calc(100vh - 26.1rem);
+    height: calc(#{$vh} - 26.1rem);
     @include landscape {
-      height: calc(100vh - 26.5rem);
+      height: calc(#{$vh} - 26.5rem);
     }
     color: $danger;
     line-height: 2rem;
@@ -257,9 +257,9 @@ export default defineComponent({
   }
 }
 .courses {
-  height: calc(100vh - 25.7rem);
+  height: calc(#{$vh} - 25.7rem);
   @include landscape {
-    height: calc(100vh - 26.1rem);
+    height: calc(#{$vh} - 26.1rem);
   }
   overflow-y: scroll;
   margin-right: -($spacing-4);

--- a/src/pages/add/index.vue
+++ b/src/pages/add/index.vue
@@ -104,7 +104,7 @@ export default defineComponent({
 .main {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 9.2rem);
+  height: calc(#{$vh} - 9.2rem);
   margin-top: $spacing-8;
   &__card {
     margin-bottom: $spacing-4;

--- a/src/pages/add/manual.vue
+++ b/src/pages/add/manual.vue
@@ -271,9 +271,9 @@ export default defineComponent({
 .main {
   margin-top: $spacing-5;
   &__mask {
-    height: calc(100vh - 16.2rem);
+    height: calc(#{$vh} - 16.2rem);
     @include landscape {
-      height: calc(100vh - 16.6rem);
+      height: calc(#{$vh} - 16.6rem);
     }
     @include scroll-mask;
     overflow-y: auto;

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -301,7 +301,7 @@ export default defineComponent({
 .main {
   margin-top: $spacing-5;
   &__search {
-    height: calc(100vh - 16.2rem);
+    height: calc(#{$vh} - 16.2rem);
     padding: $spacing-3 $spacing-0 $spacing-0;
   }
   &__button {
@@ -335,7 +335,7 @@ export default defineComponent({
     }
   }
   &__result {
-    height: calc(100vh - 26.6rem);
+    height: calc(#{$vh} - 26.6rem);
     @include scroll-mask;
     overflow-y: auto;
     padding: $spacing-2;

--- a/src/pages/add/twins.vue
+++ b/src/pages/add/twins.vue
@@ -87,9 +87,9 @@ export default defineComponent({
 .main {
   margin-top: $spacing-5;
   &__mask {
-    height: calc(100vh - 16.2rem);
+    height: calc(#{$vh} - 16.2rem);
     @include landscape {
-      height: calc(100vh - 16.6rem);
+      height: calc(#{$vh} - 16.6rem);
     }
     @include scroll-mask;
     overflow-y: auto;

--- a/src/pages/course/_id/edit.vue
+++ b/src/pages/course/_id/edit.vue
@@ -256,9 +256,9 @@ export default defineComponent({
 .main {
   margin-top: $spacing-5;
   &__mask {
-    height: calc(100vh - 16.2rem);
+    height: calc(#{$vh} - 16.2rem);
     @include landscape {
-      height: calc(100vh - 16.6rem);
+      height: calc(#{$vh} - 16.6rem);
     }
     @include scroll-mask;
     overflow-y: auto;

--- a/src/pages/course/_id/index.vue
+++ b/src/pages/course/_id/index.vue
@@ -357,7 +357,7 @@ export default defineComponent({
 
 .main {
   display: block;
-  height: calc(100vh - 8rem /*Headerとmargin-top*/);
+  height: calc(#{$vh} - 8rem /*Headerとmargin-top*/);
   margin-top: $spacing-5;
   overflow-y: auto;
   @include max-width;

--- a/src/pages/feedback.vue
+++ b/src/pages/feedback.vue
@@ -217,15 +217,15 @@ export default defineComponent({
 .main {
   margin-top: $spacing-5;
   &__mask {
-    height: calc(100vh - 16.2rem);
+    height: calc(#{$vh} - 16.2rem);
     @include landscape {
-      height: calc(100vh - 16.6rem);
+      height: calc(#{$vh} - 16.6rem);
     }
     @include scroll-mask;
     overflow-y: auto;
   }
   &__feedback {
-    height: calc(100vh - 15rem);
+    height: calc(#{$vh} - 15rem);
     padding-top: $spacing-3;
   }
   &__button {

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -378,7 +378,7 @@ export default defineComponent({
 
   @include landscape {
     border-radius: $spacing-4;
-    height: calc(100vh - 9.6rem);
+    height: calc(#{$vh} - 9.6rem);
   }
 
   &__toggle {
@@ -458,9 +458,9 @@ export default defineComponent({
 
 .special {
   grid-area: table;
-  height: calc(100vh - 14.8rem);
+  height: calc(#{$vh} - 14.8rem);
   @include landscape {
-    height: calc(100vh - 16.4rem);
+    height: calc(#{$vh} - 16.4rem);
   }
   overflow-y: scroll;
   margin-top: $spacing-3;

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -61,7 +61,7 @@ export default defineComponent({
 .login {
   @include center-flex(column);
   width: 100%;
-  height: 100vh;
+  height: calc(#{$vh});
   &__rectangle-logo {
     display: none;
     position: absolute;

--- a/src/pages/view-settings.vue
+++ b/src/pages/view-settings.vue
@@ -111,7 +111,7 @@ export default defineComponent({
 .main {
   margin-top: $spacing-5;
   &__contents {
-    height: calc(100vh - 8rem - #{$safe-area-top});
+    height: calc(#{$vh} - 8rem - #{$safe-area-top});
   }
   &__content {
     display: flex;

--- a/src/scss/_mixin.scss
+++ b/src/scss/_mixin.scss
@@ -137,13 +137,13 @@
 }
 @mixin center-fixed {
   position: fixed;
-  top: 50%;
+  top: calc(50% - #{$safe-area-top});
   left: 50%;
   transform: translateY(-50%) translateX(-50%);
 }
 @mixin center-asolute {
   position: absolute;
-  top: 50%;
+  top: calc(50% - #{$safe-area-top});
   left: 50%;
   transform: translateY(-50%) translateX(-50%);
 }

--- a/src/scss/_variable.scss
+++ b/src/scss/_variable.scss
@@ -92,6 +92,7 @@ $transition-box-shadow: box-shadow 0.18s ease;
 
 $safe-area-top: env(safe-area-inset-top);
 $safe-area-bottom: env(safe-area-inset-bottom);
+$vh: calc(100vh - #{$safe-area-top});
 
 // Media Queries
 $pc-and-tab-height: 860px;

--- a/src/templates/Sidebar.vue
+++ b/src/templates/Sidebar.vue
@@ -222,11 +222,12 @@ export default defineComponent({
 .sidebar {
   display: flex;
   flex-direction: column;
+  padding-top: $safe-area-top;
   top: 0;
   left: 0;
   width: 20.8rem;
-  height: 100vh;
-  min-height: 100%;
+  height: calc(#{$vh});
+  min-height: calc(100% - #{$safe-area-top});
   background: $base-liner;
   border-radius: 0 $radius-4 $radius-4 0;
   box-shadow: $shadow-convex;


### PR DESCRIPTION
notch用にPageHeaderへセットしたpadding(env(safe-area-inset-top))の影響で要素がはみ出していたのを修正した。
(はみだしていた原因は、safe-area-inset-top分の高さが要素のheightから削除されていなかったこと)

## 備考
- 各ページで共通して存在するmain要素のheightをsafe-area-inset-top分削る方法が一番合理的だったが、mainが内包している子要素にcalc(100vh - 〇〇rem)といったように100vhを基準として設定されているものが多くあったため、直接mainのheightを削ることができなかった。
- ↑と同じ理由でbodyやlayoutのheightからsafe-area-inset-top分削るという方法も取れなかった。

以上の理由から、現状のコードでは100vhを基準にheightが設定されているもの全てからsafe-area-inset-top分を引く必要があり、かなりメンテしづらい修正方法になってしまいました。
取り急ぎの対応なので、今後すごいコントリビューターを待つか、私の方でもっと良い方法がないか調べてみます。
