### PR TITLE
DropDown が閉じない問題を修正

### DIFF
--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -104,7 +104,7 @@ export default defineComponent({
           :key="option"
           :value="option"
           :isSelected="isSelected(option)"
-          @click="[emitSelectedEvent(option), toggleShown()]"
+          @click="[emitSelectedEvent(option), closeOptions]"
         ></DropdownContent>
       </div>
     </transition>

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -104,7 +104,7 @@ export default defineComponent({
           :key="option"
           :value="option"
           :isSelected="isSelected(option)"
-          @click="[emitSelectedEvent(option), closeOptions]"
+          @click="[emitSelectedEvent(option)]"
         ></DropdownContent>
       </div>
     </transition>


### PR DESCRIPTION
原因は
https://github.com/twin-te/twinte-front/blob/fc997f058262127398f988bbff5f05c8fda0d864/src/components/Dropdown.vue#L85
の ` v-click-away="closeOptions"` の `closeOptions` と

https://github.com/twin-te/twinte-front/blob/fc997f058262127398f988bbff5f05c8fda0d864/src/components/Dropdown.vue#L107
の `@click="[emitSelectedEvent(option), toggleShown()]"` の `toggleShown()` のイベントが同時に発火していることかと思われます。

ただ未だ原因不明な点もいくつかあります。

- PC 版では正常に動き、モバイル版でのみこの現象が発生したこと。
- デベロッパーツールでモバイル→PC版に切り替えるとまれにこのバグが発生すること。デベロッパーツールで切り替える人などいないと思うので実質的には問題ありませんが。

なんにせよ、バグの解決はしたので PR を出しました。

fix: #358
fix: #379 