### PR TITLE
fix feedback style bug

### DIFF
--- a/src/pages/feedback.vue
+++ b/src/pages/feedback.vue
@@ -58,7 +58,7 @@
           ></TextFieldSingleLine>
         </section>
       </div>
-      <section class="main__button">
+      <section class="main__footer">
         <Button
           @click="sendFeedback()"
           size="large"
@@ -209,18 +209,13 @@ export default defineComponent({
 
 .main {
   margin-top: $spacing-5;
-  &__mask {
-    height: calc(#{$vh} - 16.2rem);
-    @include landscape {
-      height: calc(#{$vh} - 16.6rem);
-    }
+  &__feedback {
+    @include scroll-mask-large;
+    height: calc(#{$vh} - 16rem);
+    padding-top: $spacing-3;
     overflow-y: auto;
   }
-  &__feedback {
-    height: calc(#{$vh} - 15rem);
-    padding-top: $spacing-3;
-  }
-  &__button {
+  &__footer {
     text-align: center;
     margin: $spacing-3 $spacing-0 $spacing-6;
     @include landscape {


### PR DESCRIPTION
revert(#408)の副作用を直した。
scrollのmaskとoverflowの設定が消えたことが原因
|before|after|
|---|---|
|<img width="361" alt="スクリーンショット 2021-04-08 1 36 49" src="https://user-images.githubusercontent.com/48097323/113920666-0b3f3800-9820-11eb-9d26-6ff023536eb9.png">|<img width="361" src="https://user-images.githubusercontent.com/48097323/113920753-2ca02400-9820-11eb-93f9-b3d4d29d19f3.png">|



