### PR TITLE
fix font-size setting in input

### DIFF
--- a/src/components/TextFieldMultilines.vue
+++ b/src/components/TextFieldMultilines.vue
@@ -36,17 +36,19 @@ export default defineComponent({
 
 <template>
   <div class="text-field-multilines">
-    <textarea
-      @input="handleInput"
-      :value="modelValue"
-      :style="{
-        width,
-        height,
-      }"
-      :placeholder="placeholder"
-      class="text-field-multilines__input"
-    >
-    </textarea>
+    <div class="text-field-multilines__scaling">
+      <textarea
+        @input="handleInput"
+        :value="modelValue"
+        :style="{
+          width,
+          height,
+        }"
+        :placeholder="placeholder"
+        class="text-field-multilines__input"
+      >
+      </textarea>
+    </div>
   </div>
 </template>
 
@@ -55,17 +57,17 @@ export default defineComponent({
 
 .text-field-multilines {
   box-shadow: $shadow-input-concave;
-  padding: $spacing-2 $spacing-4 1rem;
   border-radius: $radius-input;
+  padding: 0 $spacing-4;
   &__input {
-    display: block;
-    width: 100%;
     resize: none;
-
-    background: inherit;
-    font-size: $font-medium;
     line-height: $multi-line;
     color: getColor(--color-text-main);
+    background: inherit;
+    font-size: 1.6rem; //スマホでのinput入力時拡大防止
+    transform: scale(0.875); //$text-mediumにする
+    margin: 0 -6%; //scaleで縮んだ表示領域の調整
+
     &:focus {
       outline: none;
     }

--- a/src/components/TextFieldSingleLine.vue
+++ b/src/components/TextFieldSingleLine.vue
@@ -107,9 +107,10 @@ export default defineComponent({
     }
   }
   &__input {
-    display: block;
     width: 100%;
-    font-size: $font-medium;
+    font-size: 1.6rem; //スマホでのinput入力時拡大防止
+    transform: scale(0.875); //$text-mediumにする
+    margin: 0 -6%; //scaleで縮んだ表示領域の調整
     line-height: $fit;
     color: getColor(--color-text-main);
     &:focus {


### PR DESCRIPTION
fix #392 
iOSでinput要素入力時に自動でズームしてしまわないようにした。
font-sizeの設定を1.6rem(16px以上にしないとズームしてしまうため)にして、transformで見た目うを1.4remに戻した。

## 備考
iOSの仕様で拡大するべきと判断されているサイズのテキストを無理矢理拡大させないようにするのもアレだが、今回は極端に小さいfont-sizeではないこと、拡大された時の不便さの方が上回ること(検索ボタンを押せなくなる&授業を繰り返し追加するたびに拡大解除の操作を強いることになる)を考慮して拡大禁止にした。