### PR TITLE
fix padding bug

### DIFF
--- a/src/components/GrayFilter.vue
+++ b/src/components/GrayFilter.vue
@@ -22,7 +22,7 @@ export default defineComponent({
 
 .grayfilter {
   width: 100%;
-  height: calc(100% - #{$safe-area-top});
+  height: 100%;
   position: fixed;
   top: 0;
   left: 0;

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -393,7 +393,7 @@ export default defineComponent({
   @include landscape {
     margin: $spacing-4 $spacing-0 $spacing-0;
   }
-  height: calc(100vh - 7.6rem - #{$safe-area-top});
+  height: calc(#{$vh} - 7.6rem);
   grid-template:
     "toggle module btn" $spacing-7
     "table table table" 1fr

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -73,8 +73,9 @@ export default defineComponent({
 
 .login {
   @include center-flex(column);
+  padding-top: $safe-area-top;
   width: 100%;
-  height: calc(#{$vh});
+  height: $vh;
   &__rectangle-logo {
     display: none;
     position: absolute;

--- a/src/pages/view-settings.vue
+++ b/src/pages/view-settings.vue
@@ -131,7 +131,7 @@ export default defineComponent({
 .main {
   margin-top: $spacing-5;
   &__contents {
-    height: calc(#{$vh} - 8rem - #{$safe-area-top});
+    height: calc(#{$vh} - 8rem);
   }
   &__content {
     display: flex;

--- a/src/templates/Sidebar.vue
+++ b/src/templates/Sidebar.vue
@@ -226,8 +226,8 @@ export default defineComponent({
   top: 0;
   left: 0;
   width: 20.8rem;
-  height: calc(#{$vh});
-  min-height: calc(100% - #{$safe-area-top});
+  height: 100vh;
+  min-height: 100vh;
   background: var(--base-liner);
   border-radius: 0 $radius-4 $radius-4 0;
   box-shadow: $shadow-convex;


### PR DESCRIPTION
## 概要
画面下に余白ができていたログインページ、表示設定ページ、GrayFilter, Sidebarを直した。

|ログインページ|表示設定|GrayFilter, Sidebar|
|---|---|---|
|![IMG_8696](https://user-images.githubusercontent.com/48097323/114279249-a9284200-9a6e-11eb-9862-40f798e8c6fd.PNG)|![IMG_8695](https://user-images.githubusercontent.com/48097323/114279260-b04f5000-9a6e-11eb-9b55-344dc4bd2356.PNG)|![IMG_8694](https://user-images.githubusercontent.com/48097323/114279266-b5ac9a80-9a6e-11eb-8acf-f1a2b399335d.PNG)|





## 原因
- セーフエリア用のpaddingが設定されていなかったこと
- セーフエリア用のpadding設定を考慮せずheightが設定されていたこと
