### PR TITLE
fix loginpage

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="login">
     <div class="login__rectangle-logo">
-      <img src="../assets/twintelogo-color.svg" />
+      <img v-if="isDark" src="../assets//twintelogo-darkmode.svg" />
+      <img v-else src="../assets/twintelogo-color.svg" />
     </div>
     <div class="login__main">
       <div class="main__square-logo">
@@ -75,7 +76,7 @@ export default defineComponent({
   @include center-flex(column);
   padding-top: $safe-area-top;
   width: 100%;
-  height: $vh;
+  height: 100vh;
   &__rectangle-logo {
     display: none;
     position: absolute;

--- a/src/scss/_mixin.scss
+++ b/src/scss/_mixin.scss
@@ -154,13 +154,13 @@
 }
 @mixin center-fixed {
   position: fixed;
-  top: calc(50% - #{$safe-area-top});
+  top: calc(50% + #{$safe-area-top});
   left: 50%;
   transform: translateY(-50%) translateX(-50%);
 }
 @mixin center-asolute {
   position: absolute;
-  top: calc(50% - #{$safe-area-top});
+  top: calc(50% + #{$safe-area-top});
   left: 50%;
   transform: translateY(-50%) translateX(-50%);
 }


### PR DESCRIPTION
## 概要
#421 における修正漏れを直した。
- ログインページでまだセーフエリア分の隙間があった(ネイティブのみ)ので修正
- ついでにPC版のログインページでダークモード用の画像を設定し忘れていたので追加
- 中央揃えのmixinでセーフエリア分の値が正しく設定されていなかったので修正 (ネイティブではこのmixinを使って配置されたモーダルとかが上にずれていた)

|ログインページの隙間|中央揃えのミス|ダークモード用画像設定忘れ|
|---|---|---|
|![IMG_8700](https://user-images.githubusercontent.com/48097323/114318129-8a957a00-9b46-11eb-9aa0-fb5b216fc5ca.PNG)|![IMG_8701](https://user-images.githubusercontent.com/48097323/114318150-a862df00-9b46-11eb-99c2-b26ecfb23a52.PNG)|<img width="1222" alt="スクリーンショット 2021-04-12 4 23 17" src="https://user-images.githubusercontent.com/48097323/114318183-d3e5c980-9b46-11eb-9875-e2109de2b104.png">|




