### PR TITLE
ポップアップのメニューの幅を広く変更

### DIFF
--- a/src/pages/course/_id/index.vue
+++ b/src/pages/course/_id/index.vue
@@ -22,14 +22,14 @@
             :isActive="showPopup"
           ></ToggleIconButton>
           <Popup v-show="showPopup">
-            <PopupContent
-              v-for="data in popupData"
-              :key="data.value"
-              @click="data.onClick"
-              :link="data.link"
-              :value="data.value"
-              :color="data.color"
-            ></PopupContent>
+            <div class="popup-row" v-for="data in popupData" :key="data.value">
+              <PopupContent
+                @click="data.onClick"
+                :link="data.link"
+                :value="data.value"
+                :color="data.color"
+              ></PopupContent>
+            </div>
           </Popup>
         </div>
       </template>
@@ -422,6 +422,13 @@ export default defineComponent({
     &__minus-btn {
       grid-area: minus-btn;
     }
+  }
+}
+
+.popup-row {
+  margin: $spacing-3 0;
+  @include tab-and-pc {
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
モバイル版だと押しづらいので少しだけ広くしました。
PCは影響ありません。

**Before**
![image](https://user-images.githubusercontent.com/45098934/114428040-ac4e3a00-9bf6-11eb-8b6d-b030a8cecd54.png)

**After**
![image](https://user-images.githubusercontent.com/45098934/114428090-bbcd8300-9bf6-11eb-8b80-419fa9a2d019.png)


fix: #428