### PR TITLE
firebase で必要なモジュールのみを import するように変更

### DIFF
--- a/src/usecases/sendFeedback.ts
+++ b/src/usecases/sendFeedback.ts
@@ -1,4 +1,5 @@
-import firebase from "firebase";
+import firebase from "firebase/app";
+import "firebase/storage";
 
 const firebaseConfig = {
   apiKey: "AIzaSyACPmoxAt9e8m50mAcNE_seJWr1KV264ZU",


### PR DESCRIPTION
今まで不必要な firebase のモジュールを読み込んでいたことで警告が出ており、速度にも影響していたことから必要なモジュールのみ読み込むようにしました。
フィードバックが正常に投稿できていることも確認済みです。

![image](https://user-images.githubusercontent.com/45098934/114431673-ba9e5500-9bfa-11eb-8048-3c89e1fcd286.png)
