### PR TITLE
csvファイル選択のaccept属性を修正

### DIFF
--- a/src/pages/add/csv.vue
+++ b/src/pages/add/csv.vue
@@ -16,7 +16,7 @@
       <InputButtonFile
         name="csv-file"
         @change-file="loadCourses"
-        accept="text/csv"
+        accept=".csv"
       >
         アップロードする
       </InputButtonFile>


### PR DESCRIPTION
CSVファイル選択のacceptで"text/csv"でcsvファイルだけに制限するのは、Chrome系のブラウザは対応していないため、拡張子指定で、Chrome系でもFirefox系でも制限できるように修正しました。