### PR TITLE
fix: 振替授業の日に通常日課と表示されてしまうバグ

### DIFF
--- a/src/entities/calendar.ts
+++ b/src/entities/calendar.ts
@@ -15,7 +15,7 @@ export const getSchoolCalendarEventJa = (
 ): string => {
   const now = dayjs();
   const event = events.find((event) => {
-    return now.isSame(dayjs(event.date));
+    return now.isSame(dayjs(event.date), "day");
   });
   return event == null
     ? "通常日課"


### PR DESCRIPTION
<img width="92" alt="スクリーンショット 2021-11-25 16 43 58" src="https://user-images.githubusercontent.com/68944024/143400235-e85647fd-2ffb-4635-b407-c18fd5273521.png">

### バグ
振替授業の日に通常日課と表示されてしまう

### 対処したこと
日付(dayjs) の比較を { year, month, day } で行うように修正した.