### PR TITLE
タグの管理を Google Tag Manager に移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "firebase": "^8.3.2",
     "qs": "^6.10.1",
     "vue": "^3.0.9",
-    "vue-gtag-next": "^1.14.0",
     "vue-router": "4",
     "vue3-click-away": "^1.1.0",
     "vuex": "4"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@aspida/axios": "^1.6.3",
+    "@gtm-support/vue-gtm": "^1.3.0",
     "@sentry/browser": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "@types/qs": "^6.9.6",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import VueClickAway from "vue3-click-away";
 import { createHead } from "@vueuse/head";
 import * as Sentry from "@sentry/browser";
 import { Integrations } from "@sentry/tracing";
-import VueGtag from "vue-gtag-next";
 import { createGtm } from "@gtm-support/vue-gtm"
 
 import App from "./App.vue";
@@ -30,12 +29,6 @@ app
   .use(store, StateKey)
   .use(VueClickAway)
   .use(head)
-  .use(VueGtag, {
-    property: {
-      id: "UA-153429703-1",
-    },
-    isEnabled: import.meta.env.PROD,
-  })
   .use(createGtm({
     id: "GTM-PHSLD8B",
     vueRouter: router,

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { createHead } from "@vueuse/head";
 import * as Sentry from "@sentry/browser";
 import { Integrations } from "@sentry/tracing";
 import VueGtag from "vue-gtag-next";
+import { createGtm } from "@gtm-support/vue-gtm"
 
 import App from "./App.vue";
 import { router } from "./route";
@@ -35,6 +36,12 @@ app
     },
     isEnabled: import.meta.env.PROD,
   })
+  .use(createGtm({
+    id: "GTM-PHSLD8B",
+    vueRouter: router,
+    enabled: import.meta.env.PROD,
+    debug: import.meta.env.DEV,
+  }))
   .mount("#app");
 
 window.addEventListener("error", (event) => {

--- a/src/route.ts
+++ b/src/route.ts
@@ -1,5 +1,4 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
-import { trackRouter } from "vue-gtag-next";
 
 import App from "./pages/index.vue";
 import Login from "./pages/login.vue";
@@ -43,7 +42,5 @@ export const router = createRouter({
   history,
   routes,
 });
-
-trackRouter(router);
 
 export default router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5714,11 +5714,6 @@ vue-eslint-parser@^7.0.0:
     esquery "^1.0.1"
     lodash "^4.17.15"
 
-vue-gtag-next@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/vue-gtag-next/-/vue-gtag-next-1.14.0.tgz#793aef0b90dff4213b9f3a79827cd99b06e678dd"
-  integrity sha512-iJl+cOG2GU5NuxqzSSIpt03WVOvZqyKB9TOy7d55KiuvRklcnb2nlqxW5B/a3/sbIt7fla+XEkRyMCcoz0zAHw==
-
 vue-router@4:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.0.3.tgz#8b26050c88b2dec7e27a88835f71046b365823ec"

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,6 +593,20 @@
     lodash.camelcase "^4.3.0"
     protobufjs "^6.8.6"
 
+"@gtm-support/core@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@gtm-support/core/-/core-1.1.0.tgz#bacc66e1b64a3c6b6302bb7feb81ba506c5330ba"
+  integrity sha512-GyiZEfKejkAQq2lDS0u2mv6NDVdNWqXi+uQX0zcBOsIpWHfQxWpuCeTTCSv3DZEKv2LMkC0cwv6ukVRJvPmpaA==
+
+"@gtm-support/vue-gtm@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@gtm-support/vue-gtm/-/vue-gtm-1.3.0.tgz#b54381611c1d072a7951ef208f694eb645310c39"
+  integrity sha512-QN7BmkE6RQ9bDgfqKdC/7KBALEM1vEjgbJ83c1nO6EJ3AUuc76l44DMH2q9npueQ2Vvl1FaqscQJzYH+rxjZmg==
+  dependencies:
+    "@gtm-support/core" "1.1.0"
+  optionalDependencies:
+    vue-router "^4.0.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1188,6 +1202,11 @@
   dependencies:
     "@vue/compiler-dom" "3.0.9"
     "@vue/shared" "3.0.9"
+
+"@vue/devtools-api@^6.0.0":
+  version "6.0.12"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.12.tgz#7b57cce215ae9f37a86984633b3aa3d595aa5b46"
+  integrity sha512-iO/4FIezHKXhiDBdKySCvJVh8/mZPxHpiQrTy+PXVqJZgpTPTdHy4q8GXulaY+UKEagdkBb0onxNQZ0LNiqVhw==
 
 "@vue/eslint-config-typescript@7.0.0":
   version "7.0.0"
@@ -5704,6 +5723,13 @@ vue-router@4:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.0.3.tgz#8b26050c88b2dec7e27a88835f71046b365823ec"
   integrity sha512-AD1OjtVPyQHTSpoRsEGfPpxRQwhAhxcacOYO3zJ3KNkYP/r09mileSp6kdMQKhZWP2cFsPR3E2M3PZguSN5/ww==
+
+vue-router@^4.0.0:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.0.13.tgz#47f06e2f8ff6120bfff3c27ade1356cc9de7d870"
+  integrity sha512-LmXrC+BkDRLak+d5xTMgUYraT3Nj0H/vCbP+7usGvIl9Viqd1UP6AsP0i69pSbn9O0dXK/xCdp4yPw21HqV9Jw==
+  dependencies:
+    "@vue/devtools-api" "^6.0.0"
 
 vue3-click-away@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
# 経緯

#452

# 変更内容

## 1. [Google Tag Manager](https://tagmanager.google.com/) で新規コンテナを作成
Google Tag Manager に Twin:te アカウントでログインすることで確認できます。
コードの変更ではないですが、重要なのでここに記します。
 
## 2. [vue-gtm](https://www.npmjs.com/package/@gtm-support/vue-gtm) を用いて Google Tag Manager を導入

## 3. 既存の gtag は削除
既存のユニバーサル・アナリティクスは Google Tag Manager の管理画面経由で導入するので、ハードコードされていた計測タグは削除しました。削除しないとハードコードされたタグと、 Google Tag Manager 経由で導入されるタグが重複していまうためです。

fix: #452 