### PR TITLE
Fix saturday course

### DIFF
--- a/src/entities/day.ts
+++ b/src/entities/day.ts
@@ -1,6 +1,9 @@
 import { CourseDay } from "~/api/@types";
 
-export type WeekDay = Extract<CourseDay, "Mon" | "Tue" | "Wed" | "Thu" | "Fri">;
+export type WeekDay = Extract<
+  CourseDay,
+  "Mon" | "Tue" | "Wed" | "Thu" | "Fri" | "Sat"
+>;
 export type Day = Extract<
   CourseDay,
   "Mon" | "Tue" | "Wed" | "Thu" | "Fri" | "Sat" | "Sun"
@@ -11,13 +14,13 @@ export type SpecialDay = Extract<
 >;
 export type FullDay = Day | SpecialDay;
 
-export type WeekDayJa = "月" | "火" | "水" | "木" | "金";
-export type DayJa = "月" | "火" | "水" | "木" | "金" | "土" | "日";
+export type WeekDayJa = "月" | "火" | "水" | "木" | "金" | "土";
+export type DayJa = WeekDayJa | "日";
 export type SpecialDayJa = "集中" | "応談" | "随時";
 export type FullDayJa = DayJa | SpecialDayJa;
 export type ScheduleDayJa = FullDayJa | "指定なし";
 
-export const weekdays: WeekDay[] = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+export const weekdays: WeekDay[] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 export const week: Day[] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 export const specialDays: SpecialDay[] = [
   "Intensive",
@@ -37,7 +40,7 @@ export const fullDays: FullDay[] = [
   "AnyTime",
 ];
 
-export const weekdayJaList: WeekDayJa[] = ["月", "火", "水", "木", "金"];
+export const weekdayJaList: WeekDayJa[] = ["月", "火", "水", "木", "金", "土"];
 export const dayJaList: DayJa[] = ["月", "火", "水", "木", "金", "土", "日"];
 export const scheduleDayJaList: ScheduleDayJa[] = [
   "月",
@@ -59,6 +62,7 @@ export const weekdayMap: Record<WeekDay, WeekDayJa> = {
   Wed: "水",
   Thu: "木",
   Fri: "金",
+  Sat: "土",
 };
 export const weekMap: Record<Day, DayJa> = {
   Mon: "月",
@@ -94,9 +98,7 @@ export const weekNum = (day: Day): number => week.indexOf(day);
 export const dayToWeekJa = (day: WeekDay): WeekDayJa => weekdayMap[day];
 export const dayToJa = (day: Day): DayJa => weekMap[day];
 export const dayToFullDayja = (day: FullDay): FullDayJa => fullDayMap[day];
-
-export const dayToSpecialTableJa = (day: SpecialDay | "Weekend") =>
-  day === "Weekend" ? "土日" : specialDayMap[day];
+export const dayToSpecialDayJa = (day: SpecialDay) => specialDayMap[day];
 
 export const jaToDay = (ja: FullDayJa): CourseDay =>
   fullDays.find((key) => fullDayMap[key] === ja) ?? "Unknown";

--- a/src/entities/module.ts
+++ b/src/entities/module.ts
@@ -85,14 +85,14 @@ export const jaToBaseModule = (ja: ModuleJa): BaseModule =>
 
 /** fullModulesに対応 */
 export type ModuleFlg = [
-  boolean,
-  boolean,
-  boolean,
-  boolean,
-  boolean,
-  boolean,
-  boolean,
-  boolean
+  boolean, // 春A
+  boolean, // 春B
+  boolean, // 春C
+  boolean, // 夏休
+  boolean, // 秋A
+  boolean, // 秋B
+  boolean, // 秋C
+  boolean // 春休
 ];
 
 export const moduleFlgToDisplay = (moduleFlg: ModuleFlg): string[] => {

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -64,7 +64,9 @@
         }"
         :style="{
           gridTemplateRows: `1.4rem repeat(${bachelorMode ? 8 : 6}, 1fr)`,
-          gridTemplateColumns: `${tableTimeMode ? 3.6 : 2}rem repeat(5, 1fr)`,
+          gridTemplateColumns: `${tableTimeMode ? 3.6 : 2}rem repeat(${
+            saturdayCourseMode ? 6 : 5
+          }, 1fr)`,
         }"
         v-if="whichSelected === 'left'"
       >
@@ -101,17 +103,20 @@
         </template>
       </div>
       <section class="special" v-else>
-        <template v-for="(value, key) in specialTable" :key="key">
+        <template
+          v-for="(courses, specialDay) in specialTable"
+          :key="specialDay"
+        >
           <div class="special-header">
             <div class="special-header__label">
-              {{ dayToSpecialTableJa(key) }}
+              {{ dayToSpecialDayJa(specialDay) }}
             </div>
             <div class="special-header__divider"></div>
           </div>
           <div class="special-container">
             <div
               class="special-contents"
-              v-for="course in value"
+              v-for="course in courses"
               :key="course.id"
             >
               <div class="special-contents__module">
@@ -125,7 +130,7 @@
                 :room="course.room"
               />
             </div>
-            <div v-if="value.length === 0" class="special-contents">
+            <div v-if="courses.length === 0" class="special-contents">
               <div class="special-contents__module"></div>
               <CourseTile
                 class="special-contents__course"
@@ -239,12 +244,12 @@ import { CourseState } from "~/entities/table";
 import { getCurrentModule } from "~/usecases/getCurrentModule";
 import { ModuleJa, moduleJaList } from "~/entities/module";
 import { RegisteredCourse, Information } from "~/api/@types";
-import { dayToSpecialTableJa } from "~/entities/day";
+import { dayToSpecialDayJa } from "~/entities/day";
 import { usePorts } from "~/usecases";
 import { useRouter } from "vue-router";
 import { useSidebar } from "~/usecases/useSidebar";
 import { useSwitch } from "~/hooks/useSwitch";
-import { weekdays, WeekDayJa, weekdayJaList } from "~/entities/day";
+import { WeekDayJa, weekdayJaList } from "~/entities/day";
 import Button from "~/components/Button.vue";
 import CourseTile from "~/components/CourseTile.vue";
 import IconButton from "~/components/IconButton.vue";
@@ -268,6 +273,7 @@ import { useDisplayedModule } from "~/usecases/useDisplayedModule";
 import { useTableTimeMode } from "~/usecases/useTableTime";
 import { getNews } from "~/usecases/getNews";
 import { formatDatetime } from "~/entities/news";
+import { useSaturdayCourseMode } from "~/usecases/useSaturdayCourseMode";
 
 export default defineComponent({
   name: "Table",
@@ -311,11 +317,16 @@ export default defineComponent({
     };
 
     /** table */
+    const { saturdayCourseMode } = useSaturdayCourseMode(ports);
     const { bachelorMode } = useBachelorMode(ports);
     const { tableTimeMode } = useTableTimeMode(ports);
     const storedCourses: RegisteredCourse[] = store.getters.courses;
     const table = computed(() =>
-      courseListToTable(storedCourses, bachelorMode.value)
+      courseListToTable(
+        storedCourses,
+        saturdayCourseMode.value,
+        bachelorMode.value
+      )
     );
     const specialTable = computed(() =>
       courseListToSpecialTable(storedCourses)
@@ -390,7 +401,6 @@ export default defineComponent({
 
     return {
       toggleSidebar,
-      weekdays,
       label,
       whichSelected,
       onClickLabel,
@@ -408,10 +418,11 @@ export default defineComponent({
       undisplayedCourses,
       weeks,
       jaToBaseModule,
+      saturdayCourseMode,
       bachelorMode,
       tableTimeMode,
       tableTimeData,
-      dayToSpecialTableJa,
+      dayToSpecialDayJa,
       onClickCourseTile,
       duplicationState,
       clearDuplicationState,

--- a/src/pages/view-settings.vue
+++ b/src/pages/view-settings.vue
@@ -22,6 +22,14 @@
           />
         </div>
         <div class="main__content">
+          土曜授業を表示する
+          <ToggleSwitch
+            class="switch"
+            @click-toggle-switch="toggleSaturdayCourseMode"
+            :isChecked="saturdayCourseMode"
+          />
+        </div>
+        <div class="main__content">
           8限まで表示する(大学院生用)
           <ToggleSwitch
             class="switch"
@@ -63,6 +71,7 @@ import { usePorts } from "~/usecases";
 import { useDisplayedYear } from "~/usecases/useDisplayedYear";
 import { getCourseList } from "~/usecases/getCourseList";
 import { useTableTimeMode } from "~/usecases/useTableTime";
+import { useSaturdayCourseMode } from "~/usecases/useSaturdayCourseMode";
 
 export default defineComponent({
   components: {
@@ -78,6 +87,10 @@ export default defineComponent({
 
     const ports = usePorts();
 
+    const {
+      saturdayCourseMode,
+      toggleSaturdayCourseMode,
+    } = useSaturdayCourseMode(ports);
     const { bachelorMode, toggleBachelorMode } = useBachelorMode(ports);
     const { tableTimeMode, toggleTableTimeMode } = useTableTimeMode(ports);
     const isDark = useDark({
@@ -110,6 +123,8 @@ export default defineComponent({
     return {
       isDark,
       toggleDark,
+      saturdayCourseMode,
+      toggleSaturdayCourseMode,
       bachelorMode,
       toggleBachelorMode,
       tableTimeMode,

--- a/src/store/getter.ts
+++ b/src/store/getter.ts
@@ -20,6 +20,9 @@ export const getters: GetterTree<GlobalState, GlobalState> = {
   tableTimeMode: (state) => {
     return state.tableTimeMode;
   },
+  saturdayCourseMode: (state) => {
+    return state.saturdayCourseMode;
+  },
   toasts: (state) => {
     return state.toasts;
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -29,7 +29,7 @@ const initState: GlobalState = {
   label: "left",
   bachelorMode: false,
   tableTimeMode: true,
-  saturdayCourseMode: true,
+  saturdayCourseMode: false,
   toasts: [],
   displayedYear: null,
   module: null,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,6 +14,7 @@ export type GlobalState = {
   label: Select;
   bachelorMode: boolean;
   tableTimeMode: boolean;
+  saturdayCourseMode: boolean;
   toasts: Toast[];
   displayedYear: number | null;
   module: ModuleJa | null;
@@ -28,6 +29,7 @@ const initState: GlobalState = {
   label: "left",
   bachelorMode: false,
   tableTimeMode: true,
+  saturdayCourseMode: true,
   toasts: [],
   displayedYear: null,
   module: null,

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -26,6 +26,9 @@ export const mutations: MutationTree<GlobalState> = {
   setTableTimeMode(state, show: boolean) {
     state.tableTimeMode = show;
   },
+  setSaturdayCourseMode(state, mode: boolean) {
+    state.saturdayCourseMode = mode;
+  },
   setDisplayedYear(state, year: number | null) {
     state.displayedYear = year;
   },

--- a/src/usecases/courseListToSpecialTable.ts
+++ b/src/usecases/courseListToSpecialTable.ts
@@ -14,50 +14,40 @@ import {
 export const courseListToSpecialTable = (
   courses: RegisteredCourse[]
 ): SpecialTable => {
-  const targetCourses = courses.reduce<
-    Record<SpecialDay | "Weekend", RegisteredCourse[]>
-  >(
-    (acc, course) => {
+  const targetCourses = courses.reduce<Record<SpecialDay, RegisteredCourse[]>>(
+    (targetCourses, course) => {
       const schedules = course.schedules ?? course.course?.schedules ?? [];
-      [
-        ...new Set(
-          schedules
-            .map((s) => s.day)
-            .filter((day) => [...specialDays, "Sat", "Sun"].includes(day))
-        ),
-      ].forEach((day) => {
-        acc[day === "Sat" || day === "Sun" ? "Weekend" : day].push(course);
-      });
-
-      return acc;
+      schedules
+        .filter((schedule) => specialDays.includes(schedule.day as SpecialDay))
+        .forEach((schedule) => {
+          targetCourses[schedule.day].push(course);
+        });
+      return targetCourses;
     },
     {
       Intensive: [],
       Appointment: [],
       AnyTime: [],
-      Weekend: [],
     }
   );
 
-  return [...specialDays, "Weekend"].reduce<SpecialTable>(
-    (st, day) => {
-      st[day] = createSpecialCourseStateList(
-        targetCourses[day],
-        day === "Weekend" ? ["Sat", "Sun"] : [day as SpecialDay]
-      );
-      return st;
+  return specialDays.reduce<SpecialTable>(
+    (specialTable, day) => {
+      specialTable[day] = createSpecialCourseStateList(targetCourses[day], [
+        day,
+      ]);
+      return specialTable;
     },
     {
       Intensive: [],
       Appointment: [],
       AnyTime: [],
-      Weekend: [],
     }
   );
 };
 
 /**
- * 現時点で画面に表示されていない講義を抽出し、SpecialCourseStateに変換する
+ * 画面に表示されていない講義を抽出し、SpecialCourseStateに変換する
  */
 export const getUndisplayedCourses = (
   courses: RegisteredCourse[],
@@ -70,7 +60,7 @@ export const getUndisplayedCourses = (
         return idList.concat(table[m].flat(2).map((c) => c.id));
       }, [])
       .concat(
-        [...specialDays, "Weekend"].reduce<string[]>((idList, d) => {
+        specialDays.reduce<string[]>((idList, d) => {
           return idList.concat(specialTable[d].map((c) => c.id));
         }, [])
       )

--- a/src/usecases/courseListToTable.ts
+++ b/src/usecases/courseListToTable.ts
@@ -4,14 +4,39 @@ import { BaseModule, modules } from "~/entities/module";
 import { Table } from "~/entities/table";
 
 /**
- * ホーム画面のテーブルを作成する。
+ * n次元配列を作成する.
+ * @param ndims n次元配列の形状
+ * @param initVal 要素の初期値
+ * @returns n次元配列
+ */
+export const createNdarray = (
+  ndims: number[],
+  initVal: any = undefined
+): any[] => {
+  const ret = new Array(ndims[0]);
+
+  if (ndims.length === 1) ret.fill(initVal);
+  else {
+    for (let i = 0; i < ndims[0]; i++) {
+      ret[i] = createNdarray(ndims.slice(1), initVal);
+    }
+  }
+
+  return ret;
+};
+
+/**
+ * ホーム画面の通常授業のテーブルを作成する.
+ * 院生モードのときは7,8限を表示する.
+ * 土曜授業を表示するかは表示設定に従う.
  */
 export const courseListToTable = (
   courses: RegisteredCourse[],
+  saturdayCourseMode: boolean,
   bachelorMode: boolean
 ): Table => {
-  const table = courses.reduce(
-    (prevTable, course) => {
+  const table = courses.reduce<Table>(
+    (table, course) => {
       const name = course.name ?? course.course?.name ?? "";
       const schedules = course.schedules ?? course.course?.schedules ?? [];
       const room = [...new Set(schedules.map((s) => s.room))].join(",");
@@ -24,7 +49,7 @@ export const courseListToTable = (
             schedule.period <= 8
         )
         .forEach((schedule) =>
-          prevTable[schedule.module][weekdayNum(schedule.day as WeekDay)][
+          table[schedule.module][weekdayNum(schedule.day as WeekDay)][
             schedule.period - 1
           ].push({
             name,
@@ -33,57 +58,29 @@ export const courseListToTable = (
           })
         );
 
-      return prevTable;
+      return table;
     },
     {
-      SpringA: [
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-      ],
-      SpringB: [
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-      ],
-      SpringC: [
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-      ],
-      FallA: [
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-      ],
-      FallB: [
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-      ],
-      FallC: [
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-        [[], [], [], [], [], [], [], []],
-      ],
-    } as Table
+      SpringA: createNdarray([6, 8, 0]),
+      SpringB: createNdarray([6, 8, 0]),
+      SpringC: createNdarray([6, 8, 0]),
+      FallA: createNdarray([6, 8, 0]),
+      FallB: createNdarray([6, 8, 0]),
+      FallC: createNdarray([6, 8, 0]),
+    }
   );
 
-  if (bachelorMode) return table;
-  modules.forEach((m) => {
-    table[m] = table[m].map((arr) => arr.slice(0, 6));
-  });
+  if (!saturdayCourseMode) {
+    modules.forEach((m) => {
+      table[m] = table[m].slice(0, 5);
+    });
+  }
+
+  if (!bachelorMode) {
+    modules.forEach((m) => {
+      table[m] = table[m].map((arr) => arr.slice(0, 6));
+    });
+  }
+
   return table;
 };

--- a/src/usecases/useSaturdayCourseMode.ts
+++ b/src/usecases/useSaturdayCourseMode.ts
@@ -3,8 +3,8 @@ import { Ports } from "~/adapter";
 
 export const useSaturdayCourseMode = ({ store }: Ports) => {
   const storedSaturdayCourseMode = localStorage.getItem("saturday-course-mode");
-  if (storedSaturdayCourseMode === "off") {
-    store.commit("setSaturdayCourseMode", false);
+  if (storedSaturdayCourseMode === "on") {
+    store.commit("setSaturdayCourseMode", true);
   }
 
   const saturdayCourseMode = computed<boolean>(

--- a/src/usecases/useSaturdayCourseMode.ts
+++ b/src/usecases/useSaturdayCourseMode.ts
@@ -1,0 +1,25 @@
+import { computed } from "vue";
+import { Ports } from "~/adapter";
+
+export const useSaturdayCourseMode = ({ store }: Ports) => {
+  const storedSaturdayCourseMode = localStorage.getItem("saturday-course-mode");
+  if (storedSaturdayCourseMode === "off") {
+    store.commit("setSaturdayCourseMode", false);
+  }
+
+  const saturdayCourseMode = computed<boolean>(
+    () => store.getters.saturdayCourseMode
+  );
+
+  const toggleSaturdayCourseMode = () => {
+    if (saturdayCourseMode.value) {
+      store.commit("setSaturdayCourseMode", false);
+      localStorage.setItem("saturday-course-mode", "off");
+    } else {
+      store.commit("setSaturdayCourseMode", true);
+      localStorage.setItem("saturday-course-mode", "on");
+    }
+  };
+
+  return { saturdayCourseMode, toggleSaturdayCourseMode };
+};


### PR DESCRIPTION
## 土曜授業を通常授業として時間割に表示する

土曜授業が通常授業として時間割に表示されるように変更しました。
表示設定で"土曜授業を表示する" という項目からホーム画面の通常授業に"土曜日"を表示するかどうかを設定できます。
この項目がオフのときは、土曜授業はホーム画面の特殊授業の"その他"に表示されます。

<img width="400" alt="スクリーンショット 2022-03-08 1 28 16" src="https://user-images.githubusercontent.com/68944024/157254026-34ea12e6-8fd5-4c61-b3a6-a68b98fc297a.png">
<img width="400" alt="スクリーンショット 2022-03-08 1 28 52" src="https://user-images.githubusercontent.com/68944024/157254052-5546fa80-40e4-49b9-a321-ccbb60c12c5a.png">
<img width="400" alt="スクリーンショット 2022-03-08 23 13 07" src="https://user-images.githubusercontent.com/68944024/157254980-22d0f7a7-43fb-4508-892d-6437d4c97957.png">
<img width="400" alt="スクリーンショット 2022-03-08 1 29 24" src="https://user-images.githubusercontent.com/68944024/157254066-41d53d45-804f-4eb9-97b3-75be0ff4186b.png">
