### PR TITLE
update: 単位数の表示と編集

### DIFF
--- a/src/entities/credit.ts
+++ b/src/entities/credit.ts
@@ -1,0 +1,21 @@
+export const isValidCredit = (credit: string) => {
+  // 小数点 "."
+  const dots = credit.match(/\./g);
+
+  // 空文字列はダメ
+  if (credit === "") return false;
+
+  // 0~9と"."以外が含まれていてはダメ
+  if (/[^0-9.]/.test(credit)) return false;
+
+  // 小数点の数が2つ以上はダメ
+  if (dots && dots.length > 1) return false;
+
+  // 文頭・文末に"."がきたらダメ
+  if (/^\./.test(credit) || /\.$/.test(credit)) return false;
+
+  // 小数点以下は第１位まで
+  if (dots && credit.split(".")[1].length > 1) return false;
+
+  return true;
+};

--- a/src/pages/add/manual.vue
+++ b/src/pages/add/manual.vue
@@ -30,11 +30,19 @@
               :onClickRemoveButton="removeSchedule"
             ></ScheduleEditer>
           </section>
+          <section class="main__credit">
+            <LabeledTextField label="単位数">
+              <TextFieldSingleLine
+                v-model.trim="displayCourse.credit"
+                placeholder="例) 1.0"
+              ></TextFieldSingleLine>
+            </LabeledTextField>
+          </section>
           <section class="main__instructor">
             <LabeledTextField label="担当教員">
               <TextFieldSingleLine
                 v-model="displayCourse.instructor"
-                placeholder="例) 山田 太郎"
+                placeholder="例) 筑波 太郎"
               ></TextFieldSingleLine>
             </LabeledTextField>
           </section>
@@ -139,6 +147,7 @@ import Modal from "~/components/Modal.vue";
 import PageHeader from "~/components/PageHeader.vue";
 import ScheduleEditer from "~/components/ScheduleEditer.vue";
 import TextFieldSingleLine from "~/components/TextFieldSingleLine.vue";
+import { isValidCredit } from "~/entities/credit";
 import {
   apiToDisplayCourse,
   displayCourseToApi,
@@ -196,7 +205,9 @@ export default defineComponent({
 
     /** save button */
     const btnState = computed(() =>
-      displayCourse.name === "" || !isValidSchedules(displayCourse.schedules)
+      displayCourse.name === "" ||
+      !isValidSchedules(displayCourse.schedules) ||
+      !isValidCredit(displayCourse.credit)
         ? "disabled"
         : "default"
     );

--- a/src/pages/course/_id/edit.vue
+++ b/src/pages/course/_id/edit.vue
@@ -30,6 +30,14 @@
               :onClickRemoveButton="removeSchedule"
             ></ScheduleEditer>
           </section>
+          <section class="main__credit">
+            <LabeledTextField label="単位数">
+              <TextFieldSingleLine
+                v-model.trim="displayCourse.credit"
+                placeholder="例) 1.0"
+              ></TextFieldSingleLine>
+            </LabeledTextField>
+          </section>
           <section class="main__instructor">
             <LabeledTextField label="担当教員">
               <TextFieldSingleLine
@@ -103,6 +111,7 @@ import Modal from "~/components/Modal.vue";
 import PageHeader from "~/components/PageHeader.vue";
 import ScheduleEditer from "~/components/ScheduleEditer.vue";
 import TextFieldSingleLine from "~/components/TextFieldSingleLine.vue";
+import { isValidCredit } from "~/entities/credit";
 import { methodJaList } from "~/entities/method";
 import { createBlankSchedule, isValidSchedules } from "~/entities/schedule";
 import { displayToast } from "~/entities/toast";
@@ -155,7 +164,9 @@ export default defineComponent({
 
     /** save button */
     const btnState = computed(() =>
-      displayCourse.name === "" || !isValidSchedules(displayCourse.schedules)
+      displayCourse.name === "" ||
+      !isValidSchedules(displayCourse.schedules) ||
+      !isValidCredit(displayCourse.credit)
         ? "disabled"
         : "default"
     );

--- a/src/pages/course/_id/index.vue
+++ b/src/pages/course/_id/index.vue
@@ -42,6 +42,9 @@
           <CourseDetail item="開講時限" :value="displayCourse.date">
             <DecoratedIcon iconName="schedule"></DecoratedIcon>
           </CourseDetail>
+          <CourseDetail item="単位数" :value="displayCourse.credit">
+            <DecoratedIcon iconName="payments"></DecoratedIcon>
+          </CourseDetail>
           <CourseDetail item="担当教員" :value="displayCourse.instructor">
             <DecoratedIcon iconName="person"></DecoratedIcon>
           </CourseDetail>

--- a/src/usecases/useDisplayCourse.ts
+++ b/src/usecases/useDisplayCourse.ts
@@ -125,7 +125,7 @@ export const apiToDisplayCourse = (
     periodToString(baseCourse?.schedules ?? baseCourse.course?.schedules ?? []),
     char
   ),
-  credit: (baseCourse.credit ?? baseCourse.course?.credit ?? 0).toFixed(),
+  credit: (baseCourse.credit ?? baseCourse.course?.credit ?? 0).toFixed(1),
   instructor: blankToChar(
     baseCourse.instructor ?? baseCourse.course?.instructor,
     char


### PR DESCRIPTION
### やったこと
単位数の表示と編集をできるようにしました。
編集した単位数を保存するときは、バリデーションをしています。
無効な単位数が入力された場合は、ボタンが`disable`になります。

### 変更した画面
- 手動追加
- 授業詳細
- 授業編集

<img width="518" alt="スクリーンショット 2022-03-13 14 20 06" src="https://user-images.githubusercontent.com/68944024/158048339-2dc448ec-f4d2-47e9-a118-02a44720ee8d.png">
<img width="496" alt="スクリーンショット 2022-03-13 14 20 50" src="https://user-images.githubusercontent.com/68944024/158048341-26c493c7-871f-4562-a606-7ec08c2e18ca.png">
<img width="494" alt="スクリーンショット 2022-03-13 14 21 30" src="https://user-images.githubusercontent.com/68944024/158048342-9337df14-2214-4540-8a11-40d8e58afc36.png">
