### PR TITLE
カスタムイベントを設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ yarn dev # https://localhost:3000
 ```
 
 - 注意: [拡張機能](https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf)などでブラウザの CORS を無効にしてください
+
+# イベント測定用のマーカについて
+
+本アプリでは Google Tag Manager によるユーザイベントの測定を行っています。  
+それに伴いデータ属性`data-gtm-marker`やクラス`gtm-marker-*`のイベント発生箇所を特定するためのマーカを各要所に設置してあります。これらを修正する際は Google Tag Manager の設定も合わせて変更して下さい。

--- a/src/components/PopupContent.vue
+++ b/src/components/PopupContent.vue
@@ -21,6 +21,10 @@ export default defineComponent({
         return ["normal", "danger"].includes(value);
       },
     },
+    gtmMarker: {
+      type: String,
+      default: ""
+    }
   },
   emits: ["click"],
 });
@@ -33,6 +37,7 @@ export default defineComponent({
       'popup-content': true,
       [`popup-content--${color}`]: true,
     }"
+    :data-gtm-marker="gtmMarker"
   >
     {{ value }}
     <span v-if="link" class="material-icons popup-content__link">launch</span>

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -155,6 +155,7 @@ import { getDuplicatedCourses } from "~/usecases/getDuplicatedCourses";
 import { periodToString } from "~/usecases/periodToString";
 import { Schedule } from "~/entities/schedule";
 import { searchCourse } from "~/usecases/searchCourse";
+import { useGtm } from "@gtm-support/vue-gtm";
 import { usePorts } from "~/usecases";
 import { useRoute, useRouter } from "vue-router";
 import { useSwitch } from "~/hooks/useSwitch";
@@ -185,6 +186,7 @@ export default defineComponent({
     const route = useRoute();
     const router = useRouter();
     const ports = usePorts();
+    const gtm = useGtm();
 
     /** accordion */
     const [isAccordionOpen, toggleOpen] = useToggle(
@@ -247,6 +249,12 @@ export default defineComponent({
       if (_offset === 0) {
         searchResult.value.splice(-searchResult.value.length);
         offset = 0;
+        gtm?.trackEvent({
+          event: "search-courses",
+          term: searchWord.value,
+          use_only_blank: onlyBlank.value,
+          schedules: schedules.value
+        });
       }
       isAccordionOpen.value = false;
       let courses: Course[] = [];

--- a/src/pages/course/_id/index.vue
+++ b/src/pages/course/_id/index.vue
@@ -29,6 +29,7 @@
               :link="data.link"
               :value="data.value"
               :color="data.color"
+              :gtm-marker="data.gtmMarker"
             ></PopupContent>
           </Popup>
         </div>
@@ -69,6 +70,7 @@
               size="small"
               color="primary"
               iconName="remove"
+              data-gtm-marker="attendance-record-button"
             ></IconButton>
             <p class="attendance__count">{{ attendance }}</p>
             <IconButton
@@ -77,6 +79,7 @@
               size="small"
               color="primary"
               iconName="add"
+              data-gtm-marker="attendance-record-button"
             ></IconButton>
           </div>
           <div class="attendance__item">
@@ -87,6 +90,7 @@
               size="small"
               color="primary"
               iconName="remove"
+              data-gtm-marker="attendance-record-button"
             ></IconButton>
             <p class="attendance__count">{{ absence }}</p>
             <IconButton
@@ -95,6 +99,7 @@
               size="small"
               color="primary"
               iconName="add"
+              data-gtm-marker="attendance-record-button"
             ></IconButton>
           </div>
           <div class="attendance__item">
@@ -105,6 +110,7 @@
               size="small"
               color="primary"
               iconName="remove"
+              data-gtm-marker="attendance-record-button"
             ></IconButton>
             <p class="attendance__count">{{ late }}</p>
             <IconButton
@@ -113,6 +119,7 @@
               size="small"
               color="primary"
               iconName="add"
+              data-gtm-marker="attendance-record-button"
             ></IconButton>
           </div>
         </section>
@@ -253,24 +260,28 @@ export default defineComponent({
       link: boolean;
       value: string;
       color: popupContentColor;
+      gtmMarker: string;
     }[] = [
       {
         onClick: () => router.push(`/course/${id}/edit`),
         link: false,
         value: "編集する",
         color: "normal",
+        gtmMarker: "course-edit",
       },
       {
         onClick: () => openUrl(getSyllbusUrl(code.value)),
         link: true,
         value: "シラバス",
         color: "normal",
+        gtmMarker: "course-syllabus",
       },
       {
         onClick: () => openUrl("https://atmnb.tsukuba.ac.jp"),
         link: true,
         value: "出席(respon)",
         color: "normal",
+        gtmMarker: "course-respon",
       },
       {
         onClick: () =>
@@ -278,12 +289,14 @@ export default defineComponent({
         link: true,
         value: "地図",
         color: "normal",
+        gtmMarker: "course-map",
       },
       {
         onClick: openDeleteCourseModal,
         link: false,
         value: "削除する",
         color: "danger",
+        gtmMarker: "course-delete",
       },
     ];
 

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -33,6 +33,7 @@
             size="small"
             color="normal"
             icon-name="expand_more"
+            data-gtm-marker="selection-module-button"
             :is-active="false"
           />
           <Popup class="main__module-popup" v-show="popup">
@@ -100,7 +101,7 @@
           />
         </template>
       </div>
-      <section class="special" v-else>
+      <section class="special gtm-marker-special" v-else>
         <template v-for="(value, key) in specialTable" :key="key">
           <div class="special-header">
             <div class="special-header__label">


### PR DESCRIPTION
# 目的

各種ユーザイベントを定量的に観測し、改善施策の立案、効果測定の実行に活用したい

# 変更内容

## カスタムイベントを検知するためのマーカを設置

極力イベント計測用のコードを書きたくなかったのでマーカを設置し、設置された要素で発生したイベントを Google Tag Manager で計測する形にしました。

## 検索クエリの収集

検索クエリは上記のやり方でできなかったのでここだけ計測コードを書いています。

fix: #456 