### PR TITLE
Add credit

### DIFF
--- a/src/components/CreditCourseListContent.vue
+++ b/src/components/CreditCourseListContent.vue
@@ -1,21 +1,9 @@
 <script lang="ts">
 import { computed, defineComponent, PropType, ref } from "vue";
+import { CreditCourseState } from "~/entities/course";
+import { DisplayTag } from "~/entities/tag";
 import Tag from "./Tag.vue";
 import TagEditor from "./TagEditor.vue";
-
-export type CreditCourseListContentState = "default" | "selected";
-export type CreditCourseListContentTag = {
-  id: string;
-  name: string;
-  assign: boolean;
-};
-export type CreditCourseListContentProps = {
-  state: CreditCourseListContentState;
-  code: string;
-  name: string;
-  credit: string;
-  tags: CreditCourseListContentTag[];
-};
 
 export default defineComponent({
   name: "CreditCourseListContent",
@@ -25,7 +13,7 @@ export default defineComponent({
   },
   props: {
     state: {
-      type: String as PropType<CreditCourseListContentState>,
+      type: String as PropType<CreditCourseState>,
       default: "default",
     },
     code: {
@@ -44,7 +32,7 @@ export default defineComponent({
       required: true,
     },
     tags: {
-      type: Object as PropType<CreditCourseListContentTag[]>,
+      type: Object as PropType<DisplayTag[]>,
       required: true,
     },
   },

--- a/src/components/CreditFilter.vue
+++ b/src/components/CreditFilter.vue
@@ -335,7 +335,7 @@ export default defineComponent({
     max-height: calc(3.4rem * 6.5 + 0.8rem); // タグ6個半 + padding
     padding: $spacing-2 $spacing-0;
 
-    overflow-y: scroll;
+    overflow-y: auto;
     @include scroll-mask;
   }
 

--- a/src/components/CreditFilter.vue
+++ b/src/components/CreditFilter.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { computed, defineComponent, PropType, reactive, ref } from "vue";
+import { CreditTag } from "~/entities/tag";
 import Button from "./Button.vue";
 import Dropdown from "./Dropdown.vue";
 import IconButton from "./IconButton.vue";
@@ -7,7 +8,6 @@ import TagListContent from "./TagListContent.vue";
 import TextFieldSingleLine from "./TextFieldSingleLine.vue";
 
 export type CreditFilterMode = "filtering" | "edit";
-export type CreditFilterTag = { id: string; name: string; credit: string };
 
 export default defineComponent({
   name: "CreditFilter",
@@ -40,7 +40,7 @@ export default defineComponent({
       default: undefined,
     },
     tags: {
-      type: Object as PropType<CreditFilterTag[]>,
+      type: Object as PropType<CreditTag[]>,
       required: true,
     },
   },
@@ -56,10 +56,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const opened = ref(true);
 
-    type TagListContent = {
-      id: string;
-      name: string;
-      credit: string;
+    type TagListContent = CreditTag & {
       textfieldValue: string;
       normalBtn: "edit" | "check";
       dangerBtn: "delete" | "clear";

--- a/src/components/TagListContent.vue
+++ b/src/components/TagListContent.vue
@@ -100,6 +100,7 @@ export default defineComponent({
       font-size: $font-medium;
 
       background: var(--primary-liner);
+      box-shadow: $shadow-primary-concave;
     }
 
     &.--filtering {

--- a/src/entities/course.ts
+++ b/src/entities/course.ts
@@ -1,5 +1,6 @@
 import { MethodJa } from "./method";
 import { Schedule } from "~/entities/schedule";
+import { DisplayTag } from "./tag";
 
 export type DisplayCourse = {
   code: string; // 科目コード
@@ -15,4 +16,19 @@ export type DisplayCourse = {
   late: number; // 遅刻
   schedules: Schedule[]; // スケジュールの編集用
   methods: MethodJa[]; // 授業形式の編集用
+};
+
+// 単位数のページで使用
+export type CreditCourse = {
+  id: string;
+  code: string;
+  name: string;
+  credit: string;
+  tags: DisplayTag[];
+};
+
+export type CreditCourseState = "default" | "selected";
+
+export type CreditCourseWithState = CreditCourse & {
+  state: CreditCourseState;
 };

--- a/src/entities/tag.ts
+++ b/src/entities/tag.ts
@@ -1,0 +1,13 @@
+export type DisplayTag = { id: string; name: string; assign: boolean };
+
+export type CreditTag = { id: string; name: string; credit: string };
+
+export const isCreditTag = (tag: CreditTag | DisplayTag): tag is CreditTag => {
+  return "credit" in tag;
+};
+
+export const isDisplayTag = (
+  tag: CreditTag | DisplayTag
+): tag is DisplayTag => {
+  return "assign" in tag;
+};

--- a/src/pages/add/csv.vue
+++ b/src/pages/add/csv.vue
@@ -262,7 +262,7 @@ export default defineComponent({
   @include landscape {
     height: calc(#{$vh} - 26.1rem);
   }
-  overflow-y: scroll;
+  overflow-y: auto;
   margin-right: -($spacing-4);
   padding-right: $spacing-4;
   @include scroll-mask;

--- a/src/pages/course/_id/index.vue
+++ b/src/pages/course/_id/index.vue
@@ -348,7 +348,7 @@ export default defineComponent({
   @include scroll-mask;
   &__contents {
     padding-top: $spacing-3;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
   &__code {
     font-size: $font-small;

--- a/src/pages/credit.vue
+++ b/src/pages/credit.vue
@@ -1,0 +1,297 @@
+<template>
+  <div class="credit">
+    <PageHeader>
+      <template #left-button-icon>
+        <IconButton
+          @click="$router.back()"
+          size="large"
+          color="normal"
+          icon-name="arrow_back"
+        ></IconButton>
+      </template>
+      <template #title>単位数</template>
+    </PageHeader>
+    <section class="main">
+      <CreditFilter
+        @create-tag="onCreditFilterCreateTag"
+        @update-tag-name="onCreditFilterUpdateTagName"
+        @delete-tag="onCreditFilterDeleteTag"
+        v-model:mode="mode"
+        :year-options="yearOptions"
+        v-model:selected-year="selectedYear"
+        :total-credit="totalCredit"
+        v-model:selected-tag-id="selectedTagId"
+        :tags="creditTags"
+      >
+      </CreditFilter>
+      <div :class="{ main__mask: true, '--disabled': mode === 'edit' }">
+        <CreditCourseListContent
+          v-for="ccws in displayCreditCourseWithStateList"
+          :key="ccws.id"
+          @click="
+            ccws.state =
+              mode === 'edit' || ccws.state === 'selected'
+                ? 'default'
+                : 'selected'
+          "
+          @create-tag="
+            (tagName) => onCreditCourseListContentCreateTag(ccws, tagName)
+          "
+          @click-tag="(tag) => onCreditCourseListContentClickTag(ccws, tag)"
+          :state="ccws.state"
+          :code="ccws.code"
+          :name="ccws.name"
+          :credit="ccws.credit"
+          :tags="ccws.tags"
+        ></CreditCourseListContent>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, reactive, ref, watch } from "vue";
+import CreditCourseListContent from "~/components/CreditCourseListContent.vue";
+import CreditFilter, { CreditFilterMode } from "~/components/CreditFilter.vue";
+import IconButton from "~/components/IconButton.vue";
+import PageHeader from "~/components/PageHeader.vue";
+import { CreditCourseWithState } from "~/entities/course";
+import { CreditTag, DisplayTag } from "~/entities/tag";
+import {
+  apiToCreditCourseWithStateList,
+  apiToCreditTags,
+  getTotalCredit,
+  updateCreditCourseWithStateList,
+  updateReactiveTags,
+} from "~/usecases/creditPageFunctions";
+import {
+  ApiCourseForCredit,
+  ApiTag,
+  CourseRepositoryInMemory,
+  TagRepositoryInMemory,
+} from "~/usecases/dummyRepo";
+
+export default defineComponent({
+  name: "Credit",
+  components: {
+    CreditCourseListContent,
+    CreditFilter,
+    IconButton,
+    PageHeader,
+  },
+  setup() {
+    // api とか usecase の代わりです。
+    // 後で消します
+    const courseRepo: CourseRepositoryInMemory = new CourseRepositoryInMemory();
+    const tagRepo: TagRepositoryInMemory = new TagRepositoryInMemory();
+
+    const sortApiTagsInPlace = (apiTags: ApiTag[]): ApiTag[] => {
+      return apiTags.sort((a, b) => a.order - b.order);
+    };
+
+    /**
+     * - view は主に `creditTags` と `creditCourseWithStateList` に依存しています。
+     * - これらの値が変更されると、view が更新されます。
+     *
+     * 処理の流れ
+     * 1. `apiCourses` または `apiTags` が変更される
+     * 2. `updateView` によって `creditTags` と `creditCourseWithStateList` を更新する。
+     * 3. view が更新される
+     * 4. 1 ~ 3 の繰り返し
+     */
+
+    // これらの値が変更されたら updateView を実行する
+    const apiCourses = ref<ApiCourseForCredit[]>([]);
+    const apiTags = ref<ApiTag[]>([]);
+
+    const updateApiCourses = () => {
+      console.log("update api courses");
+
+      // TODO: api につなぐ
+      apiCourses.value = courseRepo.getCourses();
+    };
+    const updateApiTags = () => {
+      console.log("update api tags");
+
+      // TODO: api につなぐ
+      apiTags.value = sortApiTagsInPlace(tagRepo.getTags());
+    };
+
+    // initialize
+    updateApiCourses();
+    updateApiTags();
+
+    /**
+     * - view を更新する。
+     * - view は主に `creditTags` と `creditCourseWithStateList` に依存している。
+     * - `creditTags` を更新するために `updateReactiveTags` を実行する。
+     * - `creditCourseWithStateList` を更新するために `updateCreditCourseWithStateList` を実行する。
+     */
+    const updateView = () => {
+      // update creditTags
+      const newCreditTags = apiToCreditTags(apiCourses.value, apiTags.value);
+      updateReactiveTags(creditTags, newCreditTags);
+
+      // update creditCourseWithStateList
+      updateCreditCourseWithStateList(
+        creditCourseWithStateList,
+        apiCourses.value,
+        apiTags.value
+      );
+
+      console.log("creditTags", creditTags);
+      console.log("creditCourseWithStateList", creditCourseWithStateList);
+    };
+
+    /** credit-filter */
+    const mode = ref<CreditFilterMode>("filtering");
+    const yearOptions: string[] = [
+      "すべての年度",
+      "2022年度",
+      "2021年度",
+      "2020年度",
+      "2019年度",
+    ];
+    const selectedYear = ref(yearOptions[0]);
+    const totalCredit = ref(getTotalCredit(apiCourses.value));
+    const selectedTagId = ref<string | undefined>(undefined);
+    const creditTags = reactive<CreditTag[]>(
+      apiToCreditTags(apiCourses.value, apiTags.value)
+    );
+
+    const onCreditFilterCreateTag = (name: string) => {
+      // TODO: api につなぐ
+      tagRepo.createTag({ name, order: creditTags.length });
+
+      updateApiTags();
+      updateView();
+    };
+    const onCreditFilterUpdateTagName = (id: string, name: string) => {
+      // TODO: api につなぐ
+      tagRepo.updateTag(id, { name });
+
+      updateApiTags();
+      updateView();
+    };
+    const onCreditFilterDeleteTag = (id: string) => {
+      // TODO: api につなぐ
+      tagRepo.deleteTag(id);
+      courseRepo.deleteTag(id);
+
+      const tags = creditTags
+        .filter((tag) => tag.id !== id)
+        .map((tag, i) => ({ id: tag.id, order: i }));
+
+      // TODO: api につなぐ
+      tagRepo.changeOrders(tags);
+
+      updateApiTags();
+      updateView();
+    };
+
+    /** credit-course-list-content */
+    const creditCourseWithStateList: CreditCourseWithState[] = reactive(
+      apiToCreditCourseWithStateList(apiCourses.value, apiTags.value)
+    );
+    const displayCreditCourseWithStateList = computed(() => {
+      return selectedTagId.value == undefined
+        ? creditCourseWithStateList
+        : creditCourseWithStateList.filter((ccws) => {
+            const tag = ccws.tags.find((tag) => tag.id === selectedTagId.value);
+            return tag != undefined && tag.assign;
+          });
+    });
+
+    const onCreditCourseListContentCreateTag = (
+      ccws: CreditCourseWithState,
+      tagName: string
+    ) => {
+      // TODO: api につなぐ
+      const newTag = tagRepo.createTag({
+        name: tagName,
+        order: creditTags.length,
+      });
+
+      const assignedTagIds = ccws.tags
+        .filter((tag) => tag.assign)
+        .map(({ id }) => id);
+      assignedTagIds.push(newTag.id);
+
+      // TODO: api につなぐ
+      courseRepo.updateTags(ccws.id, assignedTagIds);
+
+      updateApiCourses();
+      updateApiTags();
+      updateView();
+    };
+
+    const onCreditCourseListContentClickTag = (
+      ccws: CreditCourseWithState,
+      clickedTag: DisplayTag
+    ) => {
+      if (mode.value === "edit") return;
+      const assignedTagIds = ccws.tags
+        .filter((tag) => tag.id !== clickedTag.id && tag.assign)
+        .map(({ id }) => id);
+      if (!clickedTag.assign) assignedTagIds.push(clickedTag.id);
+
+      // TODO: api につなぐ
+      courseRepo.updateTags(ccws.id, assignedTagIds);
+
+      updateApiCourses();
+      updateView();
+    };
+
+    watch(
+      () => mode.value,
+      () => {
+        creditCourseWithStateList.forEach((ccws) => (ccws.state = "default"));
+      }
+    );
+
+    return {
+      mode,
+      yearOptions,
+      selectedYear,
+      totalCredit,
+      selectedTagId,
+      creditTags,
+      onCreditFilterCreateTag,
+      onCreditFilterUpdateTagName,
+      onCreditFilterDeleteTag,
+      displayCreditCourseWithStateList,
+      onCreditCourseListContentCreateTag,
+      onCreditCourseListContentClickTag,
+    };
+  },
+});
+</script>
+
+<style scoped lang="scss">
+@import "~/scss/main.scss";
+
+.main {
+  height: calc(100vh - 6rem);
+  padding: 2.4rem 0 1.6rem;
+
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  &__mask {
+    flex-grow: 1;
+    padding: $spacing-3 $spacing-0;
+
+    overflow-y: scroll;
+    @include scroll-mask;
+
+    border-radius: $radius-2;
+
+    &.--disabled {
+      opacity: 0.2;
+      background: var(--base-liner);
+      box-shadow: $shadow-base;
+    }
+  }
+}
+</style>

--- a/src/pages/credit.vue
+++ b/src/pages/credit.vue
@@ -282,7 +282,7 @@ export default defineComponent({
     flex-grow: 1;
     padding: $spacing-3 $spacing-0;
 
-    overflow-y: scroll;
+    overflow-y: auto;
     @include scroll-mask;
 
     border-radius: $radius-2;

--- a/src/pages/credit.vue
+++ b/src/pages/credit.vue
@@ -270,6 +270,10 @@ export default defineComponent({
 <style scoped lang="scss">
 @import "~/scss/main.scss";
 
+.credit {
+  @include max-width;
+}
+
 .main {
   height: calc(100vh - 6rem);
   padding: 2.4rem 0 1.6rem;

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -562,7 +562,7 @@ export default defineComponent({
   @include landscape {
     height: calc(#{$vh} - 16.4rem);
   }
-  overflow-y: scroll;
+  overflow-y: auto;
   margin-top: $spacing-3;
 }
 

--- a/src/pages/tag-develop.vue
+++ b/src/pages/tag-develop.vue
@@ -139,13 +139,10 @@ import TagListContent from "~/components/TagListContent.vue";
 import TextFieldSingleLine from "~/components/TextFieldSingleLine.vue";
 import IconButton from "~/components/IconButton.vue";
 import TagEditor from "~/components/TagEditor.vue";
-import CreditCourseListContent, {
-  CreditCourseListContentProps,
-} from "~/components/CreditCourseListContent.vue";
-import CreditFilter, {
-  CreditFilterMode,
-  CreditFilterTag,
-} from "~/components/CreditFilter.vue";
+import CreditCourseListContent from "~/components/CreditCourseListContent.vue";
+import CreditFilter, { CreditFilterMode } from "~/components/CreditFilter.vue";
+import { CreditTag } from "~/entities/tag";
+import { CreditCourseWithState } from "~/entities/course";
 
 export default defineComponent({
   name: "TagDevelop",
@@ -187,9 +184,7 @@ export default defineComponent({
     };
 
     /** credit-course-list-content */
-    const creditCourseListContents: (CreditCourseListContentProps & {
-      id: string;
-    })[] = reactive([
+    const creditCourseListContents: CreditCourseWithState[] = reactive([
       {
         id: "1",
         state: "default",
@@ -236,7 +231,7 @@ export default defineComponent({
     const selectedYear = ref(yearOptions[0]);
     const totalCredit = ref("20.0");
     const selectedTagId = ref<string | undefined>(undefined);
-    const creditFilterTags = reactive<CreditFilterTag[]>([
+    const creditFilterTags = reactive<CreditTag[]>([
       { id: "0", name: "選択", credit: "7.0" },
       { id: "1", name: "選択必修", credit: "7.0" },
       { id: "2", name: "必修", credit: "0.0" },

--- a/src/route.ts
+++ b/src/route.ts
@@ -12,7 +12,7 @@ import Twins from "./pages/add/twins.vue";
 import ViewSettings from "./pages/view-settings.vue";
 import Feedback from "./pages/feedback.vue";
 import News from "./pages/news.vue";
-// import Credit from "./pages/credit.vue";
+import Credit from "./pages/credit.vue";
 import TagDevelop from "./pages/tag-develop.vue";
 
 const history = createWebHistory();
@@ -37,7 +37,7 @@ const routes: RouteRecordRaw[] = [
   { path: "/course/:id", component: Details },
   { path: "/Feedback", component: Feedback },
   { path: "/news", component: News },
-  // { path: "/credit", component: Credit },
+  { path: "/credit", component: Credit },
   { path: "/tag-develop", component: TagDevelop },
 ];
 

--- a/src/usecases/creditPageFunctions.ts
+++ b/src/usecases/creditPageFunctions.ts
@@ -1,0 +1,156 @@
+import { CreditCourseWithState } from "~/entities/course";
+import {
+  CreditTag,
+  DisplayTag,
+  isCreditTag,
+  isDisplayTag,
+} from "~/entities/tag";
+import { ApiCourseForCredit, ApiTag } from "./dummyRepo";
+
+/**
+ * `CreditTag[]` を作成する。
+ * `CreditTag.credit` はタグ毎の単位数を表す。
+ */
+export const apiToCreditTags = (
+  apiCourses: ApiCourseForCredit[],
+  apiTags: ApiTag[]
+): CreditTag[] => {
+  const tagIdToCredit: Record<string, number> = {};
+  apiTags.forEach(({ id }) => (tagIdToCredit[id] = 0));
+
+  apiCourses.forEach(({ credit, tags }) =>
+    tags.forEach((tagId) => {
+      if (!(tagId in tagIdToCredit))
+        throw new Error("Not found tag with id " + tagId);
+      tagIdToCredit[tagId] += Number(credit);
+    })
+  );
+
+  return apiTags.map((tag) => ({
+    id: tag.id,
+    name: tag.name,
+    credit: tagIdToCredit[tag.id].toFixed(1),
+  }));
+};
+
+/**
+ * `ApiTag[]` から `DisplayTag[]` を作成する。
+ * `assignedTagIds` に含まれるタグの `assign` の初期値は `true` になる。
+ */
+export const apiToDisplayTags = (
+  assignedTagIds: string[],
+  apiTags: ApiTag[]
+): DisplayTag[] => {
+  return apiTags.map((apiTag) => ({
+    id: apiTag.id,
+    name: apiTag.name,
+    assign: assignedTagIds.includes(apiTag.id),
+  }));
+};
+
+export const apiToCreditCourseWithStateList = (
+  apiCourses: ApiCourseForCredit[],
+  apiTags: ApiTag[]
+): CreditCourseWithState[] => {
+  return apiCourses.map(({ id, name, code, credit, tags: assignedTagIds }) => ({
+    id,
+    name,
+    code,
+    credit: credit.toFixed(1),
+    state: "default",
+    tags: apiToDisplayTags(assignedTagIds, apiTags),
+  }));
+};
+
+/**
+ * view の変更を最小限にするために、リアクティビティを失わずに `CreditTag` または `DisplayTag` を更新する。
+ * タグの追加、削除、`id` 以外のプロパティの変更を行う。
+ *
+ * @param reactiveTags リアクティブな配列
+ * @param compTags 比較対象となる配列
+ */
+export const updateReactiveTags = <T extends CreditTag | DisplayTag>(
+  reactiveTags: T[],
+  compTags: T[]
+) => {
+  const reactiveTagIds = reactiveTags.map((tag) => tag.id);
+  const compTagIds = compTags.map((tag) => tag.id);
+
+  const commonTagIds = reactiveTagIds.filter((id) => compTagIds.includes(id));
+  const newTagIds = compTagIds.filter((id) => !commonTagIds.includes(id));
+  const deletedTagIds = reactiveTagIds.filter(
+    (id) => !commonTagIds.includes(id)
+  );
+
+  // delete tags
+  const deleteTagIndices = reactiveTagIds.reduce<number[]>(
+    (indices, id, idx) => {
+      if (deletedTagIds.includes(id)) indices.push(idx);
+      return indices;
+    },
+    []
+  );
+  deleteTagIndices.reverse().forEach((i) => reactiveTags.splice(i, 1));
+
+  // add tags
+  const newTags = compTags.filter((tag) => newTagIds.includes(tag.id));
+  newTags.forEach((tag) => reactiveTags.push(tag));
+
+  // update tag property
+  const reactiveCommonTags = reactiveTags.filter((tag) =>
+    commonTagIds.includes(tag.id)
+  );
+  const compCommonTags = compTags.filter((tag) =>
+    commonTagIds.includes(tag.id)
+  );
+  reactiveCommonTags.forEach((reactiveTag, idx) => {
+    const compTag = compCommonTags[idx];
+    reactiveTag.name = compTag.name;
+    if (isCreditTag(reactiveTag) && isCreditTag(compTag))
+      reactiveTag.credit = compTag.credit;
+    if (isDisplayTag(reactiveTag) && isDisplayTag(compTag))
+      reactiveTag.assign = compTag.assign;
+  });
+
+  // この時点で reactiveTags に変更が行われたため、 reactiveTags と compTags の要素は一致しており、順番のみが異なる。
+
+  // update order
+  const idToOrder = compTags.reduce<Record<string, number>>(
+    (idToOrder, tag, i) => {
+      idToOrder[tag.id] = i;
+      return idToOrder;
+    },
+    {}
+  );
+  reactiveTags.sort((a, b) => idToOrder[a.id] - idToOrder[b.id]);
+};
+
+/**
+ * view の変更を最小限にするために、リアクティビティを失わずに `reactiveCreditCourseWithStateList` を更新する。
+ * タグの追加、削除、タグ名と `assign` の変更を行う。
+ *
+ * @param reactiveCreditCourseWithStateList リアクティブな配列
+ * @param apiCourses
+ * @param apiTags
+ */
+export const updateCreditCourseWithStateList = (
+  reactiveCreditCourseWithStateList: CreditCourseWithState[],
+  apiCourses: ApiCourseForCredit[],
+  apiTags: ApiTag[]
+) => {
+  reactiveCreditCourseWithStateList.forEach(({ id, tags: reactiveTags }) => {
+    const apiCourse = apiCourses.find((course) => course.id === id);
+    if (apiCourse == undefined) return;
+    const compTags = apiToDisplayTags(apiCourse.tags, apiTags);
+    updateReactiveTags(reactiveTags, compTags);
+  });
+};
+
+/**
+ * 合計単位数を取得する
+ */
+export const getTotalCredit = (apiCourses: ApiCourseForCredit[]): string => {
+  return apiCourses
+    .reduce((credit, course) => credit + Number(course.credit), 0)
+    .toFixed(1);
+};

--- a/src/usecases/dummyRepo.ts
+++ b/src/usecases/dummyRepo.ts
@@ -1,0 +1,114 @@
+export type ApiCourseForCredit = {
+  id: string;
+  name: string;
+  code: string;
+  credit: number;
+  tags: string[];
+};
+export type TagWithoutId = { name: string; order: number };
+export type ApiTag = { id: string } & TagWithoutId;
+
+export class CourseRepositoryInMemory {
+  private _courses: ApiCourseForCredit[];
+
+  constructor() {
+    this._courses = [
+      {
+        id: "0",
+        name: "色彩計画論特講",
+        code: "01EB512",
+        credit: 1.5,
+        tags: ["3"],
+      },
+      {
+        id: "1",
+        name: "応用体育シューティングスポーツ",
+        code: "EB51201",
+        credit: 2.0,
+        tags: ["4", "5"],
+      },
+      {
+        id: "2",
+        name: "Introduction to Industrial Ecology",
+        code: "EG60571",
+        credit: 1.5,
+        tags: ["0", "1", "3"],
+      },
+      {
+        id: "3",
+        name: "メディアアート・フィジカルコンピューティング",
+        code: "1E06001",
+        credit: 1.5,
+        tags: [],
+      },
+    ];
+  }
+
+  public getCourses(): ApiCourseForCredit[] {
+    return this._courses;
+  }
+
+  public updateTags(id: string, tags: string[]): ApiCourseForCredit {
+    const course = this._courses.find((course) => course.id === id);
+    if (course == undefined)
+      throw new Error("Not Found course with id " + id + ".");
+    course.tags = tags;
+    return course;
+  }
+
+  public deleteTag(tagId: string): void {
+    this._courses.forEach((course) => {
+      const idx = course.tags.findIndex((id) => id === tagId);
+      if (idx === -1) return;
+      course.tags.splice(idx, 1);
+    });
+  }
+}
+
+const createId = () => String(Math.floor(Math.random() * 10000000));
+
+export class TagRepositoryInMemory {
+  private _tags: ApiTag[];
+
+  constructor() {
+    this._tags = [
+      { id: "0", name: "専門", order: 0 },
+      { id: "1", name: "専門基礎", order: 1 },
+      { id: "2", name: "自由", order: 2 },
+      { id: "3", name: "教職", order: 3 },
+      { id: "4", name: "必修", order: 6 },
+      { id: "5", name: "選択", order: 5 },
+      { id: "6", name: "学士基盤", order: 4 },
+    ];
+  }
+
+  public getTags(): ApiTag[] {
+    return this._tags;
+  }
+
+  public createTag(tagWithoutId: TagWithoutId): ApiTag {
+    const tag = { id: createId(), ...tagWithoutId };
+    this._tags.push(tag);
+    return tag;
+  }
+
+  public updateTag(id: string, tagWithoutId: Partial<TagWithoutId>): ApiTag {
+    const idx = this._tags.findIndex((tag) => tag.id === id);
+    if (idx == -1) throw new Error("Not Found tag with id " + id + ".");
+    const name: string = tagWithoutId?.name ?? this._tags[idx].name;
+    const order: number = tagWithoutId?.order ?? this._tags[idx].order;
+    const updatedTag = { id, name, order };
+    this._tags.splice(idx, 1, updatedTag);
+    return updatedTag;
+  }
+
+  public deleteTag(id: string): void {
+    const idx = this._tags.findIndex((tag) => tag.id === id);
+    if (idx == -1) throw new Error("Not Found tag with id " + id + ".");
+    this._tags.splice(idx, 1);
+  }
+
+  public changeOrders(tags: { id: string; order: number }[]): void {
+    tags.forEach((tag) => this.updateTag(tag.id, { order: tag.order }));
+  }
+}


### PR DESCRIPTION
### やったこと
- 単位数のページを追加しました。
- `/credit`から確認できます。
- tag関連の`entity`の整理も行いました。

### 備考
- Figma ではわかりにくい細かな挙動などもこのPRで確認したいです。
- ローカル環境でも動くようになっているので確認していただきたいです。

### ファイルの説明
- `src/usecases/dummyRepo.ts` -> api や vuex の代わりです。後で消します。
- `src/usecases/creditPageFunctions.ts` -> `src/pages/credit` で使用する処理を書いています。
- `src/pages/credit.ts` -> 単位数のページ
