### PR TITLE
検索カスタムイベントの schedules param を JSON Stringify する

### DIFF
--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -260,7 +260,7 @@ export default defineComponent({
           event: "search-courses",
           term: searchWord.value,
           use_only_blank: onlyBlank.value,
-          schedules: schedules.value,
+          schedules: JSON.stringify(schedules.value),
         });
       }
       isAccordionOpen.value = false;


### PR DESCRIPTION
Google Analitics では Object は String 形式に変換され [Object Object] と表示され解析できないため `JSON.stringify` を噛ませました。
解析時には `JSON.parse` を行います。