### PR TITLE
Feat 成績ファイルのフォーマットに対応

### DIFF
--- a/src/pages/add/csv.vue
+++ b/src/pages/add/csv.vue
@@ -110,6 +110,7 @@ import IconButton from "~/components/IconButton.vue";
 import InputButtonFile from "~/components/InputButtonFile.vue";
 import Modal from "~/components/Modal.vue";
 import PageHeader from "~/components/PageHeader.vue";
+import { getYear } from "~/usecases/getYear";
 
 export default defineComponent({
   name: "CSV",
@@ -168,7 +169,22 @@ export default defineComponent({
       loadedCourses.value = [];
       let courseCodes: string[] = [];
       try {
-        courseCodes = await getCoursesIdByFile(file);
+        const csv = await getCoursesIdByFile(file);
+        switch (csv.type) {
+          case "risyu":
+            courseCodes = csv.data;
+            break;
+          case "seiseki": {
+            const year = await getYear(ports);
+            displayToast(ports)(`${year}年度の授業を読み込んでいます。`, {
+              type: "primary",
+            });
+            courseCodes = csv.data
+              .filter((v) => v.year === year)
+              .map((v) => v.code);
+            break;
+          }
+        }
       } catch (error) {
         console.error(error);
         displayToast(ports)("ファイルの読み込みに失敗しました。");
@@ -177,6 +193,12 @@ export default defineComponent({
 
       let fetchedCourses: Course[] = [];
       let missingCourseCodes: string[] = [];
+
+      if (courseCodes.length === 0) {
+        displayToast(ports)(`読み込むコースがありません。`);
+        return;
+      }
+
       try {
         const res = await getCoursesByCode(ports)(courseCodes);
         fetchedCourses = res.courses;

--- a/src/usecases/bulkAddCourseById.ts
+++ b/src/usecases/bulkAddCourseById.ts
@@ -19,12 +19,13 @@ export const bulkAddCourseById = (ports: Ports) => async (codes: string[]) => {
     .catch(() => {
       throw new NetworkError();
     });
-  if (Array.isArray(body)) {
-    body.map((course) => store.commit("addCourse", course));
-  } else {
-    store.commit("addCourse", body);
-  }
+
   if (isValidStatus(status)) {
+    if (Array.isArray(body)) {
+      body.map((course) => store.commit("addCourse", course));
+    } else {
+      store.commit("addCourse", body);
+    }
     return body;
   } else {
     console.error(body);

--- a/src/usecases/readCSV.ts
+++ b/src/usecases/readCSV.ts
@@ -1,14 +1,30 @@
+import { BaseError } from "./error";
+
+const union = <T>(arr: T[]) => [...new Set(arr)];
+
 export const getCoursesIdByFile = (file: File): Promise<string[]> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.readAsText(file);
     reader.onload = () => {
       if (typeof reader.result !== "string") return;
-      const courses = reader.result
+      const line = reader.result
         .split(/\r\n|\r|\n/)
         .filter((v) => v) // drop blank line
         .map((v) => v.replace(/"/g, ""));
-      resolve(courses);
+
+      // 履修フォーマット
+      if (line[0].length === 7) {
+        resolve(line);
+      }
+
+      // 成績フォーマット
+      if (line[0].split(",").length === 11) {
+        line.splice(0, 1); // delete header
+        resolve(union(line.map((v) => v.split(",")[2])));
+      }
+
+      throw new BaseError("このフォーマット形式に対応していません");
     };
     reader.onerror = (error) => reject(error);
   });


### PR DESCRIPTION
# やったこと

resolve #494 

成績ファイルから表示年度のみをインポートします。
ちゃんとトーストが出る親切設計です。

# レビュー箇所

@KanadeNishizawa  UX確認
@HosokawaR @hayato24s コードレビュー（どちらか一方でおけ）

このイシューに対して反論あればここでお願いします。

# プレビュー

一つ目が履修ファイル（これまで通り）
二つ目は成績ファイル

https://user-images.githubusercontent.com/39324739/161504060-632b0631-efdd-424d-9738-a8d3f941b898.mp4


