### PR TITLE
検索改善

### DIFF
--- a/src/api/$api.ts
+++ b/src/api/$api.ts
@@ -1,27 +1,50 @@
-import type { AspidaClient, BasicHeaders } from 'aspida'
-import { dataToURLString } from 'aspida'
-import type { Methods as Methods0 } from './courses'
-import type { Methods as Methods1 } from './courses/_year@number/_code@string'
-import type { Methods as Methods2 } from './courses/search'
-import type { Methods as Methods3 } from './donation/aggregate/totalAmount'
-import type { Methods as Methods4 } from './donation/aggregate/users'
-import type { Methods as Methods5 } from './donation/payment'
-import type { Methods as Methods6 } from './donation/session/onetime'
-import type { Methods as Methods7 } from './donation/session/subscription'
-import type { Methods as Methods8 } from './donation/subscriptions'
-import type { Methods as Methods9 } from './donation/subscriptions/_id@string'
-import type { Methods as Methods10 } from './donation/users/me'
-import type { Methods as Methods11 } from './information'
-import type { Methods as Methods12 } from './information/_id@string'
-import type { Methods as Methods13 } from './registered-courses'
-import type { Methods as Methods14 } from './registered-courses/_id@string'
-import type { Methods as Methods15 } from './school-calendar/events'
-import type { Methods as Methods16 } from './school-calendar/modules'
-import type { Methods as Methods17 } from './tags'
-import type { Methods as Methods18 } from './tags/_id@string'
-import type { Methods as Methods19 } from './timetable/_date@string'
-import type { Methods as Methods20 } from './users/me'
+/* eslint-disable */
+// prettier-ignore
+import { AspidaClient, BasicHeaders, dataToURLString } from 'aspida'
+// prettier-ignore
+import { Methods as Methods0 } from './courses'
+// prettier-ignore
+import { Methods as Methods1 } from './courses/_year@number/_code@string'
+// prettier-ignore
+import { Methods as Methods2 } from './courses/search'
+// prettier-ignore
+import { Methods as Methods3 } from './donation/aggregate/totalAmount'
+// prettier-ignore
+import { Methods as Methods4 } from './donation/aggregate/users'
+// prettier-ignore
+import { Methods as Methods5 } from './donation/payment'
+// prettier-ignore
+import { Methods as Methods6 } from './donation/session/onetime'
+// prettier-ignore
+import { Methods as Methods7 } from './donation/session/subscription'
+// prettier-ignore
+import { Methods as Methods8 } from './donation/subscriptions'
+// prettier-ignore
+import { Methods as Methods9 } from './donation/subscriptions/_id@string'
+// prettier-ignore
+import { Methods as Methods10 } from './donation/users/me'
+// prettier-ignore
+import { Methods as Methods11 } from './information'
+// prettier-ignore
+import { Methods as Methods12 } from './information/_id@string'
+// prettier-ignore
+import { Methods as Methods13 } from './registered-courses'
+// prettier-ignore
+import { Methods as Methods14 } from './registered-courses/_id@string'
+// prettier-ignore
+import { Methods as Methods15 } from './school-calendar/events'
+// prettier-ignore
+import { Methods as Methods16 } from './school-calendar/modules'
+// prettier-ignore
+import { Methods as Methods17 } from './tags'
+// prettier-ignore
+import { Methods as Methods18 } from './tags/_id@string'
+// prettier-ignore
+import { Methods as Methods19 } from './timetable/_date@string'
+// prettier-ignore
+import { Methods as Methods20 } from './users/me'
 
+// prettier-ignore
 const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   const prefix = (baseURL === undefined ? 'http://localhost:3000/' : baseURL).replace(/\/$/, '')
   const PATH0 = '/courses'
@@ -59,12 +82,12 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
               /**
                * @returns 成功
                */
-              get: (option?: { config?: T | undefined } | undefined) =>
+              get: (option?: { config?: T }) =>
                 fetch<Methods1['get']['resBody'], BasicHeaders, Methods1['get']['status']>(prefix, prefix2, GET, option).json(),
               /**
                * @returns 成功
                */
-              $get: (option?: { config?: T | undefined } | undefined) =>
+              $get: (option?: { config?: T }) =>
                 fetch<Methods1['get']['resBody'], BasicHeaders, Methods1['get']['status']>(prefix, prefix2, GET, option).json().then(r => r.body),
               $path: () => `${prefix}${prefix2}`
             }
@@ -76,13 +99,13 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
          * @param option.body - 検索クエリ
          * @returns 成功
          */
-        post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
+        post: (option: { body: Methods2['post']['reqBody'], config?: T }) =>
           fetch<Methods2['post']['resBody'], BasicHeaders, Methods2['post']['status']>(prefix, PATH1, POST, option).json(),
         /**
          * @param option.body - 検索クエリ
          * @returns 成功
          */
-        $post: (option: { body: Methods2['post']['reqBody'], config?: T | undefined }) =>
+        $post: (option: { body: Methods2['post']['reqBody'], config?: T }) =>
           fetch<Methods2['post']['resBody'], BasicHeaders, Methods2['post']['status']>(prefix, PATH1, POST, option).json().then(r => r.body),
         $path: () => `${prefix}${PATH1}`
       },
@@ -90,15 +113,15 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
        * 指定した複数の講義を取得する。 指定された講義が一部見つからない場合もエラーなく完了するが、 それらは結果には含まれない。
        * @returns 成功
        */
-      get: (option: { query: Methods0['get']['query'], config?: T | undefined }) =>
+      get: (option: { query: Methods0['get']['query'], config?: T }) =>
         fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).json(),
       /**
        * 指定した複数の講義を取得する。 指定された講義が一部見つからない場合もエラーなく完了するが、 それらは結果には含まれない。
        * @returns 成功
        */
-      $get: (option: { query: Methods0['get']['query'], config?: T | undefined }) =>
+      $get: (option: { query: Methods0['get']['query'], config?: T }) =>
         fetch<Methods0['get']['resBody'], BasicHeaders, Methods0['get']['status']>(prefix, PATH0, GET, option).json().then(r => r.body),
-      $path: (option?: { method?: 'get' | undefined; query: Methods0['get']['query'] } | undefined) =>
+      $path: (option?: { method?: 'get'; query: Methods0['get']['query'] }) =>
         `${prefix}${PATH0}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
     },
     donation: {
@@ -107,12 +130,12 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           /**
            * @returns 成功
            */
-          get: (option?: { config?: T | undefined } | undefined) =>
+          get: (option?: { config?: T }) =>
             fetch<Methods3['get']['resBody'], BasicHeaders, Methods3['get']['status']>(prefix, PATH2, GET, option).json(),
           /**
            * @returns 成功
            */
-          $get: (option?: { config?: T | undefined } | undefined) =>
+          $get: (option?: { config?: T }) =>
             fetch<Methods3['get']['resBody'], BasicHeaders, Methods3['get']['status']>(prefix, PATH2, GET, option).json().then(r => r.body),
           $path: () => `${prefix}${PATH2}`
         },
@@ -120,12 +143,12 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           /**
            * @returns 成功
            */
-          get: (option?: { config?: T | undefined } | undefined) =>
+          get: (option?: { config?: T }) =>
             fetch<Methods4['get']['resBody'], BasicHeaders, Methods4['get']['status']>(prefix, PATH3, GET, option).json(),
           /**
            * @returns 成功
            */
-          $get: (option?: { config?: T | undefined } | undefined) =>
+          $get: (option?: { config?: T }) =>
             fetch<Methods4['get']['resBody'], BasicHeaders, Methods4['get']['status']>(prefix, PATH3, GET, option).json().then(r => r.body),
           $path: () => `${prefix}${PATH3}`
         }
@@ -134,12 +157,12 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
         /**
          * @returns 成功
          */
-        get: (option?: { config?: T | undefined } | undefined) =>
+        get: (option?: { config?: T }) =>
           fetch<Methods5['get']['resBody'], BasicHeaders, Methods5['get']['status']>(prefix, PATH4, GET, option).json(),
         /**
          * @returns 成功
          */
-        $get: (option?: { config?: T | undefined } | undefined) =>
+        $get: (option?: { config?: T }) =>
           fetch<Methods5['get']['resBody'], BasicHeaders, Methods5['get']['status']>(prefix, PATH4, GET, option).json().then(r => r.body),
         $path: () => `${prefix}${PATH4}`
       },
@@ -148,12 +171,12 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           /**
            * @returns 成功
            */
-          post: (option: { body: Methods6['post']['reqBody'], config?: T | undefined }) =>
+          post: (option: { body: Methods6['post']['reqBody'], config?: T }) =>
             fetch<Methods6['post']['resBody'], BasicHeaders, Methods6['post']['status']>(prefix, PATH5, POST, option).json(),
           /**
            * @returns 成功
            */
-          $post: (option: { body: Methods6['post']['reqBody'], config?: T | undefined }) =>
+          $post: (option: { body: Methods6['post']['reqBody'], config?: T }) =>
             fetch<Methods6['post']['resBody'], BasicHeaders, Methods6['post']['status']>(prefix, PATH5, POST, option).json().then(r => r.body),
           $path: () => `${prefix}${PATH5}`
         },
@@ -161,12 +184,12 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           /**
            * @returns 成功
            */
-          post: (option: { body: Methods7['post']['reqBody'], config?: T | undefined }) =>
+          post: (option: { body: Methods7['post']['reqBody'], config?: T }) =>
             fetch<Methods7['post']['resBody'], BasicHeaders, Methods7['post']['status']>(prefix, PATH6, POST, option).json(),
           /**
            * @returns 成功
            */
-          $post: (option: { body: Methods7['post']['reqBody'], config?: T | undefined }) =>
+          $post: (option: { body: Methods7['post']['reqBody'], config?: T }) =>
             fetch<Methods7['post']['resBody'], BasicHeaders, Methods7['post']['status']>(prefix, PATH6, POST, option).json().then(r => r.body),
           $path: () => `${prefix}${PATH6}`
         }
@@ -176,9 +199,9 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           const prefix2 = `${PATH7}/${val2}`
 
           return {
-            delete: (option?: { config?: T | undefined } | undefined) =>
+            delete: (option?: { config?: T }) =>
               fetch<void, BasicHeaders, Methods9['delete']['status']>(prefix, prefix2, DELETE, option).send(),
-            $delete: (option?: { config?: T | undefined } | undefined) =>
+            $delete: (option?: { config?: T }) =>
               fetch<void, BasicHeaders, Methods9['delete']['status']>(prefix, prefix2, DELETE, option).send().then(r => r.body),
             $path: () => `${prefix}${prefix2}`
           }
@@ -186,12 +209,12 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
         /**
          * @returns 成功
          */
-        get: (option?: { config?: T | undefined } | undefined) =>
+        get: (option?: { config?: T }) =>
           fetch<Methods8['get']['resBody'], BasicHeaders, Methods8['get']['status']>(prefix, PATH7, GET, option).json(),
         /**
          * @returns 成功
          */
-        $get: (option?: { config?: T | undefined } | undefined) =>
+        $get: (option?: { config?: T }) =>
           fetch<Methods8['get']['resBody'], BasicHeaders, Methods8['get']['status']>(prefix, PATH7, GET, option).json().then(r => r.body),
         $path: () => `${prefix}${PATH7}`
       },
@@ -200,22 +223,22 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           /**
            * @returns 成功
            */
-          get: (option?: { config?: T | undefined } | undefined) =>
+          get: (option?: { config?: T }) =>
             fetch<Methods10['get']['resBody'], BasicHeaders, Methods10['get']['status']>(prefix, PATH8, GET, option).json(),
           /**
            * @returns 成功
            */
-          $get: (option?: { config?: T | undefined } | undefined) =>
+          $get: (option?: { config?: T }) =>
             fetch<Methods10['get']['resBody'], BasicHeaders, Methods10['get']['status']>(prefix, PATH8, GET, option).json().then(r => r.body),
           /**
            * @returns 成功
            */
-          patch: (option: { body: Methods10['patch']['reqBody'], config?: T | undefined }) =>
+          patch: (option: { body: Methods10['patch']['reqBody'], config?: T }) =>
             fetch<Methods10['patch']['resBody'], BasicHeaders, Methods10['patch']['status']>(prefix, PATH8, PATCH, option).json(),
           /**
            * @returns 成功
            */
-          $patch: (option: { body: Methods10['patch']['reqBody'], config?: T | undefined }) =>
+          $patch: (option: { body: Methods10['patch']['reqBody'], config?: T }) =>
             fetch<Methods10['patch']['resBody'], BasicHeaders, Methods10['patch']['status']>(prefix, PATH8, PATCH, option).json().then(r => r.body),
           $path: () => `${prefix}${PATH8}`
         }
@@ -226,9 +249,9 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
         const prefix1 = `${PATH9}/${val1}`
 
         return {
-          put: (option: { body: Methods12['put']['reqBody'], config?: T | undefined }) =>
+          put: (option: { body: Methods12['put']['reqBody'], config?: T }) =>
             fetch<void, BasicHeaders, Methods12['put']['status']>(prefix, prefix1, PUT, option).send(),
-          $put: (option: { body: Methods12['put']['reqBody'], config?: T | undefined }) =>
+          $put: (option: { body: Methods12['put']['reqBody'], config?: T }) =>
             fetch<void, BasicHeaders, Methods12['put']['status']>(prefix, prefix1, PUT, option).send().then(r => r.body),
           $path: () => `${prefix}${prefix1}`
         }
@@ -236,14 +259,14 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
       /**
        * @returns 成功
        */
-      get: (option: { query: Methods11['get']['query'], config?: T | undefined }) =>
+      get: (option: { query: Methods11['get']['query'], config?: T }) =>
         fetch<Methods11['get']['resBody'], BasicHeaders, Methods11['get']['status']>(prefix, PATH9, GET, option).json(),
       /**
        * @returns 成功
        */
-      $get: (option: { query: Methods11['get']['query'], config?: T | undefined }) =>
+      $get: (option: { query: Methods11['get']['query'], config?: T }) =>
         fetch<Methods11['get']['resBody'], BasicHeaders, Methods11['get']['status']>(prefix, PATH9, GET, option).json().then(r => r.body),
-      $path: (option?: { method?: 'get' | undefined; query: Methods11['get']['query'] } | undefined) =>
+      $path: (option?: { method?: 'get'; query: Methods11['get']['query'] }) =>
         `${prefix}${PATH9}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
     },
     registered_courses: {
@@ -254,26 +277,26 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           /**
            * @returns 成功
            */
-          get: (option?: { config?: T | undefined } | undefined) =>
+          get: (option?: { config?: T }) =>
             fetch<Methods14['get']['resBody'], BasicHeaders, Methods14['get']['status']>(prefix, prefix1, GET, option).json(),
           /**
            * @returns 成功
            */
-          $get: (option?: { config?: T | undefined } | undefined) =>
+          $get: (option?: { config?: T }) =>
             fetch<Methods14['get']['resBody'], BasicHeaders, Methods14['get']['status']>(prefix, prefix1, GET, option).json().then(r => r.body),
           /**
            * @returns 成功
            */
-          put: (option: { body: Methods14['put']['reqBody'], config?: T | undefined }) =>
+          put: (option: { body: Methods14['put']['reqBody'], config?: T }) =>
             fetch<Methods14['put']['resBody'], BasicHeaders, Methods14['put']['status']>(prefix, prefix1, PUT, option).json(),
           /**
            * @returns 成功
            */
-          $put: (option: { body: Methods14['put']['reqBody'], config?: T | undefined }) =>
+          $put: (option: { body: Methods14['put']['reqBody'], config?: T }) =>
             fetch<Methods14['put']['resBody'], BasicHeaders, Methods14['put']['status']>(prefix, prefix1, PUT, option).json().then(r => r.body),
-          delete: (option?: { config?: T | undefined } | undefined) =>
+          delete: (option?: { config?: T }) =>
             fetch<void, BasicHeaders, Methods14['delete']['status']>(prefix, prefix1, DELETE, option).send(),
-          $delete: (option?: { config?: T | undefined } | undefined) =>
+          $delete: (option?: { config?: T }) =>
             fetch<void, BasicHeaders, Methods14['delete']['status']>(prefix, prefix1, DELETE, option).send().then(r => r.body),
           $path: () => `${prefix}${prefix1}`
         }
@@ -281,24 +304,24 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
       /**
        * @returns 成功
        */
-      get: (option: { query: Methods13['get']['query'], config?: T | undefined }) =>
+      get: (option: { query: Methods13['get']['query'], config?: T }) =>
         fetch<Methods13['get']['resBody'], BasicHeaders, Methods13['get']['status']>(prefix, PATH10, GET, option).json(),
       /**
        * @returns 成功
        */
-      $get: (option: { query: Methods13['get']['query'], config?: T | undefined }) =>
+      $get: (option: { query: Methods13['get']['query'], config?: T }) =>
         fetch<Methods13['get']['resBody'], BasicHeaders, Methods13['get']['status']>(prefix, PATH10, GET, option).json().then(r => r.body),
       /**
        * @returns 成功
        */
-      post: (option: { body: Methods13['post']['reqBody'], config?: T | undefined }) =>
+      post: (option: { body: Methods13['post']['reqBody'], config?: T }) =>
         fetch<Methods13['post']['resBody'], BasicHeaders, Methods13['post']['status']>(prefix, PATH10, POST, option).json(),
       /**
        * @returns 成功
        */
-      $post: (option: { body: Methods13['post']['reqBody'], config?: T | undefined }) =>
+      $post: (option: { body: Methods13['post']['reqBody'], config?: T }) =>
         fetch<Methods13['post']['resBody'], BasicHeaders, Methods13['post']['status']>(prefix, PATH10, POST, option).json().then(r => r.body),
-      $path: (option?: { method?: 'get' | undefined; query: Methods13['get']['query'] } | undefined) =>
+      $path: (option?: { method?: 'get'; query: Methods13['get']['query'] }) =>
         `${prefix}${PATH10}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
     },
     school_calendar: {
@@ -306,28 +329,28 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
         /**
          * @returns 成功
          */
-        get: (option: { query: Methods15['get']['query'], config?: T | undefined }) =>
+        get: (option: { query: Methods15['get']['query'], config?: T }) =>
           fetch<Methods15['get']['resBody'], BasicHeaders, Methods15['get']['status']>(prefix, PATH11, GET, option).json(),
         /**
          * @returns 成功
          */
-        $get: (option: { query: Methods15['get']['query'], config?: T | undefined }) =>
+        $get: (option: { query: Methods15['get']['query'], config?: T }) =>
           fetch<Methods15['get']['resBody'], BasicHeaders, Methods15['get']['status']>(prefix, PATH11, GET, option).json().then(r => r.body),
-        $path: (option?: { method?: 'get' | undefined; query: Methods15['get']['query'] } | undefined) =>
+        $path: (option?: { method?: 'get'; query: Methods15['get']['query'] }) =>
           `${prefix}${PATH11}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
       },
       modules: {
         /**
          * @returns 成功
          */
-        get: (option: { query: Methods16['get']['query'], config?: T | undefined }) =>
+        get: (option: { query: Methods16['get']['query'], config?: T }) =>
           fetch<Methods16['get']['resBody'], BasicHeaders, Methods16['get']['status']>(prefix, PATH12, GET, option).json(),
         /**
          * @returns 成功
          */
-        $get: (option: { query: Methods16['get']['query'], config?: T | undefined }) =>
+        $get: (option: { query: Methods16['get']['query'], config?: T }) =>
           fetch<Methods16['get']['resBody'], BasicHeaders, Methods16['get']['status']>(prefix, PATH12, GET, option).json().then(r => r.body),
-        $path: (option?: { method?: 'get' | undefined; query: Methods16['get']['query'] } | undefined) =>
+        $path: (option?: { method?: 'get'; query: Methods16['get']['query'] }) =>
           `${prefix}${PATH12}${option && option.query ? `?${dataToURLString(option.query)}` : ''}`
       }
     },
@@ -339,16 +362,16 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           /**
            * @returns 成功
            */
-          put: (option: { body: Methods18['put']['reqBody'], config?: T | undefined }) =>
+          put: (option: { body: Methods18['put']['reqBody'], config?: T }) =>
             fetch<Methods18['put']['resBody'], BasicHeaders, Methods18['put']['status']>(prefix, prefix1, PUT, option).json(),
           /**
            * @returns 成功
            */
-          $put: (option: { body: Methods18['put']['reqBody'], config?: T | undefined }) =>
+          $put: (option: { body: Methods18['put']['reqBody'], config?: T }) =>
             fetch<Methods18['put']['resBody'], BasicHeaders, Methods18['put']['status']>(prefix, prefix1, PUT, option).json().then(r => r.body),
-          delete: (option?: { config?: T | undefined } | undefined) =>
+          delete: (option?: { config?: T }) =>
             fetch<void, BasicHeaders, Methods18['delete']['status']>(prefix, prefix1, DELETE, option).send(),
-          $delete: (option?: { config?: T | undefined } | undefined) =>
+          $delete: (option?: { config?: T }) =>
             fetch<void, BasicHeaders, Methods18['delete']['status']>(prefix, prefix1, DELETE, option).send().then(r => r.body),
           $path: () => `${prefix}${prefix1}`
         }
@@ -356,38 +379,38 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
       /**
        * @returns 成功
        */
-      get: (option?: { config?: T | undefined } | undefined) =>
+      get: (option?: { config?: T }) =>
         fetch<Methods17['get']['resBody'], BasicHeaders, Methods17['get']['status']>(prefix, PATH13, GET, option).json(),
       /**
        * @returns 成功
        */
-      $get: (option?: { config?: T | undefined } | undefined) =>
+      $get: (option?: { config?: T }) =>
         fetch<Methods17['get']['resBody'], BasicHeaders, Methods17['get']['status']>(prefix, PATH13, GET, option).json().then(r => r.body),
       /**
        * 新しいタグは末尾に追加されます
        * @returns 成功
        */
-      post: (option: { body: Methods17['post']['reqBody'], config?: T | undefined }) =>
+      post: (option: { body: Methods17['post']['reqBody'], config?: T }) =>
         fetch<Methods17['post']['resBody'], BasicHeaders, Methods17['post']['status']>(prefix, PATH13, POST, option).json(),
       /**
        * 新しいタグは末尾に追加されます
        * @returns 成功
        */
-      $post: (option: { body: Methods17['post']['reqBody'], config?: T | undefined }) =>
+      $post: (option: { body: Methods17['post']['reqBody'], config?: T }) =>
         fetch<Methods17['post']['resBody'], BasicHeaders, Methods17['post']['status']>(prefix, PATH13, POST, option).json().then(r => r.body),
       /**
        * positionを変更するタグのidとpositionの配列を送信してください。
        * positionが重複している場合はエラーになります。
        * @returns 成功
        */
-      patch: (option: { body: Methods17['patch']['reqBody'], config?: T | undefined }) =>
+      patch: (option: { body: Methods17['patch']['reqBody'], config?: T }) =>
         fetch<Methods17['patch']['resBody'], BasicHeaders, Methods17['patch']['status']>(prefix, PATH13, PATCH, option).json(),
       /**
        * positionを変更するタグのidとpositionの配列を送信してください。
        * positionが重複している場合はエラーになります。
        * @returns 成功
        */
-      $patch: (option: { body: Methods17['patch']['reqBody'], config?: T | undefined }) =>
+      $patch: (option: { body: Methods17['patch']['reqBody'], config?: T }) =>
         fetch<Methods17['patch']['resBody'], BasicHeaders, Methods17['patch']['status']>(prefix, PATH13, PATCH, option).json().then(r => r.body),
       $path: () => `${prefix}${PATH13}`
     },
@@ -399,12 +422,12 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
           /**
            * @returns 成功
            */
-          get: (option?: { config?: T | undefined } | undefined) =>
+          get: (option?: { config?: T }) =>
             fetch<Methods19['get']['resBody'], BasicHeaders, Methods19['get']['status']>(prefix, prefix1, GET, option).json(),
           /**
            * @returns 成功
            */
-          $get: (option?: { config?: T | undefined } | undefined) =>
+          $get: (option?: { config?: T }) =>
             fetch<Methods19['get']['resBody'], BasicHeaders, Methods19['get']['status']>(prefix, prefix1, GET, option).json().then(r => r.body),
           $path: () => `${prefix}${prefix1}`
         }
@@ -415,12 +438,12 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
         /**
          * @returns 成功
          */
-        get: (option?: { config?: T | undefined } | undefined) =>
+        get: (option?: { config?: T }) =>
           fetch<Methods20['get']['resBody'], BasicHeaders, Methods20['get']['status']>(prefix, PATH15, GET, option).json(),
         /**
          * @returns 成功
          */
-        $get: (option?: { config?: T | undefined } | undefined) =>
+        $get: (option?: { config?: T }) =>
           fetch<Methods20['get']['resBody'], BasicHeaders, Methods20['get']['status']>(prefix, PATH15, GET, option).json().then(r => r.body),
         $path: () => `${prefix}${PATH15}`
       }
@@ -428,5 +451,7 @@ const api = <T>({ baseURL, fetch }: AspidaClient<T>) => {
   }
 }
 
+// prettier-ignore
 export type ApiInstance = ReturnType<typeof api>
+// prettier-ignore
 export default api

--- a/src/api/@types/index.ts
+++ b/src/api/@types/index.ts
@@ -16,7 +16,7 @@ export type SchoolCalendarEvent = {
   date: string
   eventType: 'PublicHoliday' | 'Holiday' | 'Exam' | 'SubstituteDay' | 'Other'
   description: string
-  changeTo?: CourseDay | undefined
+  changeTo?: CourseDay
 }
 
 export type SchoolCalendarModule = {
@@ -46,54 +46,54 @@ export type Course = {
 export type RegisteredCourse = {
   id: string
   userId: string
-  course?: Course | undefined
+  course?: Course
 } & RegisteredCourseWithoutID
 
 export type SearchCourseTimetableQuery = {
-  SpringA?: SearchCourseTimetableQueryDays | undefined
-  SpringB?: SearchCourseTimetableQueryDays | undefined
-  SpringC?: SearchCourseTimetableQueryDays | undefined
-  FallA?: SearchCourseTimetableQueryDays | undefined
-  FallB?: SearchCourseTimetableQueryDays | undefined
-  FallC?: SearchCourseTimetableQueryDays | undefined
-  SummerVacation?: SearchCourseTimetableQueryDays | undefined
-  SpringVacation?: SearchCourseTimetableQueryDays | undefined
+  SpringA: SearchCourseTimetableQueryDays
+  SpringB: SearchCourseTimetableQueryDays
+  SpringC: SearchCourseTimetableQueryDays
+  FallA: SearchCourseTimetableQueryDays
+  FallB: SearchCourseTimetableQueryDays
+  FallC: SearchCourseTimetableQueryDays
+  SummerVacation: SearchCourseTimetableQueryDays
+  SpringVacation: SearchCourseTimetableQueryDays
 }
 
 export type SearchCourseTimetableQueryDays = {
-  Sun?: SearchCourseTimetableQueryPeriods | undefined
-  Mon?: SearchCourseTimetableQueryPeriods | undefined
-  Tue?: SearchCourseTimetableQueryPeriods | undefined
-  Wed?: SearchCourseTimetableQueryPeriods | undefined
-  Thu?: SearchCourseTimetableQueryPeriods | undefined
-  Fri?: SearchCourseTimetableQueryPeriods | undefined
-  Sat?: SearchCourseTimetableQueryPeriods | undefined
-  Intensive?: SearchCourseTimetableQueryPeriods | undefined
-  Appointment?: SearchCourseTimetableQueryPeriods | undefined
-  AnyTime?: SearchCourseTimetableQueryPeriods | undefined
+  Sun: SearchCourseTimetableQueryPeriods
+  Mon: SearchCourseTimetableQueryPeriods
+  Tue: SearchCourseTimetableQueryPeriods
+  Wed: SearchCourseTimetableQueryPeriods
+  Thu: SearchCourseTimetableQueryPeriods
+  Fri: SearchCourseTimetableQueryPeriods
+  Sat: SearchCourseTimetableQueryPeriods
+  Intensive: SearchCourseTimetableQueryPeriods
+  Appointment: SearchCourseTimetableQueryPeriods
+  AnyTime: SearchCourseTimetableQueryPeriods
 }
 
 /** 指定しなかった場合はfalseとみなされます */
 export type SearchCourseTimetableQueryPeriods = {
   /** 時限が不明な授業は0になっているためそれらも検索したい場合はtrueに（集中授業に多い） */
-  '0'?: boolean | undefined
-  '1'?: boolean | undefined
-  '2'?: boolean | undefined
-  '3'?: boolean | undefined
-  '4'?: boolean | undefined
-  '5'?: boolean | undefined
-  '6'?: boolean | undefined
-  '7'?: boolean | undefined
-  '8'?: boolean | undefined
+  '0': boolean
+  '1': boolean
+  '2': boolean
+  '3': boolean
+  '4': boolean
+  '5': boolean
+  '6': boolean
+  '7': boolean
+  '8': boolean
 }
 
 export type RegisteredCourseWithoutID = {
   year: number
-  name?: string | undefined
-  instructor?: string | undefined
-  credit?: number | undefined
-  methods?: CourseMethod[] | undefined
-  schedules?: CourseSchedule[] | undefined
+  name?: string
+  instructor?: string
+  credit?: number
+  methods?: CourseMethod[]
+  schedules?: CourseSchedule[]
   memo: string
   attendance: number
   absence: number
@@ -105,7 +105,7 @@ export type Tag = {
   id: string
   userId: string
   name: string
-  position?: number | undefined
+  position?: number
 }
 
 export type TagPositionOnly = {
@@ -144,8 +144,8 @@ export type Subscription = {
 export type PaymentUser = {
   paymentUserId: string
   twinteUserId: string
-  displayName?: string | undefined
-  link?: string | undefined
+  displayName?: string
+  link?: string
 }
 
 export type Information = {
@@ -153,7 +153,7 @@ export type Information = {
   title: string
   content: string
   publishedAt: string
-  read?: boolean | undefined
+  read?: boolean
 }
 
 export type Error = {

--- a/src/api/courses/search/index.ts
+++ b/src/api/courses/search/index.ts
@@ -11,11 +11,12 @@ export type Methods = {
     reqBody: {
       year: number
       /** 検索モード Cover 指定した時限と講義の開講日時が一部でも被っていれば対象とみなす Contain 指定した時限に収まっている講義のみ対象とみなす デフォルトはCover */
-      searchMode?: 'Cover' | 'Contain' | undefined
+      searchMode?: 'Cover' | 'Contain'
       keywords: string[]
-      limit?: number | undefined
-      offset?: number | undefined
-      timetable?: Types.SearchCourseTimetableQuery | undefined
+      codes?: string[]
+      limit?: number
+      offset?: number
+      timetable?: Types.SearchCourseTimetableQuery
     }
   }
 }

--- a/src/api/timetable/_date@string/index.ts
+++ b/src/api/timetable/_date@string/index.ts
@@ -8,7 +8,7 @@ export type Methods = {
     /** 成功 */
     resBody: {
       date: string
-      module?: Types.SchoolCalendarModule | undefined
+      module?: Types.SchoolCalendarModule
       events: Types.SchoolCalendarEvent[]
       courses: Types.RegisteredCourse[]
     }

--- a/src/components/CardCourse.stories.ts
+++ b/src/components/CardCourse.stories.ts
@@ -19,8 +19,13 @@ export const Default = Template.bind({});
 const dummyCourse: CourseCard = {
   id: "FB12721",
   name: "計算機科学",
-  period: "2.0",
+  period: "秋A 月1,2",
   location: "6A203",
+  credit: 2.0,
+  instructor: "統計 太郎",
+  methods: "オンデマンド",
+  overview:
+    "初等的な数理統計学について知り、データの見方・考え方について説明できるようになる事を目的とする.初等的な数理統計学について知り、データの見方・考え方について説明できるようになる事を目的とする.",
   url: "https://kdb.tsukuba.ac.jp/syllabi/2021/FB12721/jpn/",
   isSelected: false,
 };
@@ -28,4 +33,6 @@ const dummyCourse: CourseCard = {
 Default.args = {
   isChecked: false,
   course: dummyCourse,
+  expanded: false,
+  detailed: true,
 };

--- a/src/components/CardCourse.vue
+++ b/src/components/CardCourse.vue
@@ -2,17 +2,24 @@
 import { CourseCard } from "~/entities/courseCard";
 import { defineComponent, PropType } from "vue";
 import Button from "./Button.vue";
-import Card from "./Card.vue";
 import Checkbox from "./Checkbox.vue";
 import CourseDetailMini from "./CourseDetailMini.vue";
 import { openUrl } from "~/usecases/openUrl";
 
 export default defineComponent({
-  components: { Card, Button, CourseDetailMini, Checkbox },
+  components: { Button, CourseDetailMini, Checkbox },
   props: {
     isChecked: {
       type: Boolean,
       required: true,
+    },
+    isDetailed: {
+      type: Boolean,
+      default: true,
+    },
+    isExpanded: {
+      type: Boolean,
+      default: false,
     },
     course: {
       type: Object as PropType<CourseCard>,
@@ -23,8 +30,11 @@ export default defineComponent({
       default: "100%",
     },
   },
-  emits: ["click-checkbox"],
+  emits: ["click-card", "click-checkbox"],
   setup(props, { emit }) {
+    const emitCardEvent = (e: MouseEvent) => {
+      emit("click-card", e);
+    };
     const emitCheckboxEvent = (e: MouseEvent) => {
       emit("click-checkbox", e);
     };
@@ -32,33 +42,75 @@ export default defineComponent({
       openUrl(props.course.url);
     };
 
-    return { emitCheckboxEvent, openSyllabus };
+    return { emitCardEvent, emitCheckboxEvent, openSyllabus };
   },
 });
 </script>
 
 <template>
-  <Card :width="width">
-    <div class="card-course">
-      <div class="card-course__checkbox">
+  <div @click="emitCardEvent" :style="{ width }">
+    <div
+      :class="{
+        'card-course': true,
+        '--detailed': isDetailed,
+        '--expanded': isExpanded,
+      }"
+    >
+      <div :class="{ 'card-course__checkbox': true, '--expanded': isExpanded }">
         <Checkbox
-          @clickCheckbox="emitCheckboxEvent"
+          @clickCheckbox.stop="emitCheckboxEvent"
           :isChecked="isChecked"
         ></Checkbox>
       </div>
       <div class="card-course__courseId">{{ course.id }}</div>
       <div class="card-course__courseName">{{ course.name }}</div>
-      <div class="card-course__detail">
+      <div
+        :class="{
+          'card-course__detail': true,
+          '--expanded': isExpanded || isDetailed,
+        }"
+      >
         <CourseDetailMini
           iconName="schedule"
           :text="course.period"
         ></CourseDetailMini>
         <CourseDetailMini
+          iconName="payments"
+          :text="`${course.credit.toFixed(1)}`"
+        ></CourseDetailMini>
+        <CourseDetailMini
+          iconName="person"
+          :text="course.instructor"
+        ></CourseDetailMini>
+        <CourseDetailMini
           iconName="room"
           :text="course.location"
         ></CourseDetailMini>
+        <CourseDetailMini
+          iconName="category"
+          :text="course.methods"
+        ></CourseDetailMini>
       </div>
-      <div class="card-course__syllabus-link">
+      <div
+        :class="{
+          'card-course__overview': true,
+          '--detailed': isDetailed,
+          '--expanded': isExpanded,
+        }"
+      >
+        {{ course.overview }}
+      </div>
+      <div
+        :class="{ 'card-course__expand-icon': true, '--expanded': isExpanded }"
+      >
+        <span class="material-icons">expand_more</span>
+      </div>
+      <div
+        :class="{
+          'card-course__syllabus-link': true,
+          '--expanded': isExpanded,
+        }"
+      >
         <Button
           @click="openSyllabus"
           size="small"
@@ -69,7 +121,8 @@ export default defineComponent({
         >
       </div>
     </div>
-  </Card>
+    <div class="hr" />
+  </div>
 </template>
 
 <style scoped lang="scss">
@@ -78,14 +131,44 @@ export default defineComponent({
 .card-course {
   display: grid;
   grid-template:
-    "checkbox ... courseId   courseId  " auto
-    "checkbox ... ...        ...       " $spacing-1
-    "checkbox ... courseName courseName" auto
-    "checkbox ... ...        ...       " $spacing-1
-    "checkbox ... detail     ...       " 1fr
-    "checkbox ... detail     link      " auto
-    / auto $spacing-5 1fr auto;
+    "checkbox ... courseId   courseId   ... ...    ..." auto
+    "checkbox ... ...        ...        ... ...    ..." $spacing-1
+    "checkbox ... courseName courseName ... expand ..." auto
+    / auto $spacing-5 1fr auto 0 auto $spacing-1 auto $spacing-1;
+  &.--detailed {
+    grid-template:
+      "checkbox ... courseId   courseId   ... ...    ..." auto
+      "checkbox ... ...        ...        ... ...    ..." $spacing-1
+      "checkbox ... courseName courseName ... expand ..." auto
+      "checkbox ... ...        ...        ... expand ..." $spacing-1
+      "checkbox ... detail     detail     ... expand ..." 1fr
+      "checkbox ... overview   overview   ... expand ..." auto
+      "checkbox ... ...        ...        ... ...    ..." $spacing-2
+      "checkbox ... ...        link       ... ...    ..." auto
+      / auto $spacing-5 1fr auto 0 auto $spacing-1 auto $spacing-1;
+  }
+  &.--expanded {
+    grid-template:
+      "checkbox ... courseId   courseId    ...   " auto
+      "checkbox ... ...        ...         ...   " $spacing-1
+      "checkbox ... courseName courseName  expand" auto
+      "checkbox ... ...        ...         expand" $spacing-1
+      "checkbox ... detail     detail      expand" 1fr
+      "checkbox ... overview   overview    expand" auto
+      "checkbox ... ...        ...         ...   " $spacing-2
+      "checkbox ... ...        link        ...   " auto
+      / auto $spacing-5 1fr auto 0 auto;
+  }
   text-align: left;
+  @include pc {
+    grid-template:
+      "checkbox ... courseId   ... ...    ... link" auto
+      "checkbox ... ...        ... detail ... link" $spacing-1
+      "checkbox ... courseName ... detail ... link" 1fr
+      "checkbox ... ...        ... detail ... link" $spacing-1
+      "checkbox ... overview   ... detail ... link" auto
+      / auto $spacing-5 1fr $spacing-7 20rem $spacing-7 auto;
+  }
   &__checkbox {
     @include center-flex;
     grid-area: checkbox;
@@ -102,13 +185,75 @@ export default defineComponent({
     white-space: nowrap;
   }
   &__detail {
-    @include center-flex(column);
     grid-area: detail;
-    align-items: flex-start;
+    display: none;
+    flex-wrap: wrap;
+    align-content: flex-start;
+    justify-content: flex-start;
+    gap: 0 $spacing-2;
+    &.--expanded {
+      display: flex;
+    }
+    @include pc {
+      .course-detail-mini {
+        flex: 0 0 calc(50% - #{$spacing-2 / 2});
+        justify-content: flex-start;
+      }
+    }
+  }
+  &__overview {
+    grid-area: overview;
+    display: none;
+    line-height: $multi-line;
+    transition: $transition-all;
+    max-height: 2.2rem;
+    &.--detailed {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      @include pc {
+        white-space: normal;
+      }
+    }
+    &.--expanded {
+      display: block;
+      white-space: normal;
+      max-height: 100%;
+    }
+  }
+  &__expand-icon {
+    @include button-cursor;
+    grid-area: expand;
+    display: flex;
+    align-items: flex-end;
+    padding-bottom: $spacing-1;
+    width: 1.6rem;
+    @include pc {
+      display: none;
+    }
+    &.--expanded {
+      display: none;
+    }
   }
   &__syllabus-link {
     @include center-flex;
     grid-area: link;
+    display: none;
+    @include pc {
+      display: flex;
+    }
+    &.--expanded {
+      display: flex;
+    }
   }
+}
+
+.hr {
+  width: 100%;
+  height: 0.4rem;
+  margin-top: $spacing-3;
+  background-color: getColor(--color-base);
+  box-shadow: $shadow-input-concave;
 }
 </style>

--- a/src/components/Label.vue
+++ b/src/components/Label.vue
@@ -12,12 +12,17 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    style: {
+      type: String,
+      default: "normal",
+      validator: (value: string) => ["normal", "slim"].includes(value),
+    },
   },
 });
 </script>
 
 <template>
-  <div class="label">
+  <div :class="`label --${style}`">
     {{ value }}
     <span v-if="mandatory" class="label__mandatory">必須</span>
   </div>
@@ -34,6 +39,11 @@ export default defineComponent({
   font-weight: 500;
   line-height: $single-line;
   color: getColor(--color-text-main);
+  &.--slim {
+    font-size: $font-minimum;
+    font-weight: 500;
+    color: getColor(--color-text-sub);
+  }
   &__mandatory {
     font-size: $font-minimum;
     font-weight: 400;

--- a/src/components/LabeledTextField.stories.ts
+++ b/src/components/LabeledTextField.stories.ts
@@ -1,0 +1,33 @@
+import LabeledTextField from "~/components/LabeledTextField.vue";
+import TextFieldSingleLine from "~/components/TextFieldSingleLine.vue";
+import { Story } from "@storybook/vue3";
+
+export default {
+  component: LabeledTextField,
+};
+
+const Template: Story = (args) => ({
+  components: { LabeledTextField, TextFieldSingleLine },
+  setup() {
+    return { args };
+  },
+  template: `
+    <LabeledTextField v-bind="args">
+      <TextFieldSingleLine />
+    </LabeledTextField>
+  `,
+});
+
+export const Normal = Template.bind({});
+
+Normal.args = {
+  label: "キーワード",
+  style: "normal",
+};
+
+export const Slim = Template.bind({});
+
+Slim.args = {
+  label: "キーワード",
+  style: "slim",
+};

--- a/src/components/LabeledTextField.vue
+++ b/src/components/LabeledTextField.vue
@@ -16,6 +16,11 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    style: {
+      type: String,
+      default: "normal",
+      validator: (value: string) => ["normal", "slim"].includes(value),
+    },
   },
 });
 </script>
@@ -27,8 +32,8 @@ export default defineComponent({
       '--mandatory': mandatory,
     }"
   >
-    <div class="labeled-text-field__label">
-      <Label :value="label" :mandatory="mandatory"></Label>
+    <div :class="`labeled-text-field__label --${style}`">
+      <Label :value="label" :mandatory="mandatory" :style="style"></Label>
     </div>
     <div class="labeled-text-field__text-field">
       <slot />
@@ -43,6 +48,9 @@ export default defineComponent({
   height: 6.8rem;
   &__label {
     margin-bottom: $spacing-2;
+    &.--slim {
+      margin-bottom: $spacing-1;
+    }
   }
 }
 </style>

--- a/src/entities/courseCard.ts
+++ b/src/entities/courseCard.ts
@@ -1,11 +1,16 @@
 import { Course, CourseSchedule } from "~/api/@types";
 import { periodToString } from "~/usecases/periodToString";
+import { methodToJa } from "~/entities/method";
 
 export type CourseCard = {
   id: string;
   name: string;
   period: string;
   location: string;
+  credit: number;
+  instructor: string;
+  overview: string;
+  methods: string;
   url: string;
   isSelected: boolean;
 };
@@ -31,6 +36,10 @@ export const courseToCard = (
     name: course.name,
     period: periodToString(course.schedules),
     location: locationToString(course.schedules),
+    credit: course.credit,
+    instructor: course.instructor,
+    overview: course.overview,
+    methods: course.methods.map(methodToJa).join(", "),
     url: getSyllbusUrl(course.code, course.year),
     isSelected: isSelect,
   };

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -114,6 +114,15 @@
                 ></CardCourse>
               </div>
             </Card>
+            <div
+              v-show="searchResult.length === 0 && !isNoResultShow"
+              class="result__description"
+            >
+              <p>
+                ※授業データは筑波大学の教育課程編成支援システム(KdB)より取得しています。
+              </p>
+              <p>※毎朝5:00に更新されます。</p>
+            </div>
             <div class="result__not-found" v-if="isNoResultShow">
               {{ searchWord }}に一致する授業がありません。
             </div>
@@ -632,6 +641,13 @@ export default defineComponent({
 }
 
 .result {
+  &__description {
+    line-height: $multi-line;
+    color: getColor(--color-text-sub);
+    p {
+      margin-bottom: $spacing-1;
+    }
+  }
   &__row {
     margin-bottom: $spacing-3;
   }

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -19,7 +19,7 @@
               <TextFieldSingleLine
                 v-model.trim="searchCode"
                 @enter-text-field="search(0)"
-                placeholder="例）GA"
+                placeholder="例）GA -0"
                 :height="3.4"
               >
               </TextFieldSingleLine>

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -14,12 +14,26 @@
     <div class="main">
       <div class="main__search">
         <section class="search__top">
+          <div class="top__course-code">
+            <LabeledTextField label="科目番号" style="slim">
+              <TextFieldSingleLine
+                v-model.trim="searchCode"
+                @enter-text-field="search(0)"
+                placeholder="例）GA"
+                :height="3.4"
+              >
+              </TextFieldSingleLine>
+            </LabeledTextField>
+          </div>
           <div class="top__course-name">
-            <TextFieldSingleLine
-              v-model.trim="searchWord"
-              @enterTextField="search(0)"
-              placeholder="授業名や科目番号  (例 :「情報 倫理」,「GA」など)"
-            ></TextFieldSingleLine>
+            <LabeledTextField label="キーワード" style="slim">
+              <TextFieldSingleLine
+                v-model.trim="searchWord"
+                @enterTextField="search(0)"
+                placeholder="例）情報 倫理"
+                :height="3.4"
+              ></TextFieldSingleLine>
+            </LabeledTextField>
           </div>
           <div class="top__search-button">
             <IconButton
@@ -252,6 +266,7 @@ import TextFieldSingleLine from "~/components/TextFieldSingleLine.vue";
 import ToggleButton from "~/components/ToggleButton.vue";
 import Card from "~/components/Card.vue";
 import { flipSet } from "~/util";
+import LabeledTextField from "~/components/LabeledTextField.vue";
 
 export default defineComponent({
   components: {
@@ -266,6 +281,7 @@ export default defineComponent({
     ScheduleEditer,
     TextFieldSingleLine,
     ToggleButton,
+    LabeledTextField,
   },
   setup() {
     const route = useRoute();
@@ -363,6 +379,7 @@ export default defineComponent({
     let limit = 50;
     const isNoResultShow = ref(false);
     const searchWord = ref("");
+    const searchCode = ref("");
     const fetching = ref(false);
     const search = async (_offset = offset) => {
       fetching.value = true;
@@ -372,6 +389,7 @@ export default defineComponent({
         gtm?.trackEvent({
           event: "search-courses",
           term: searchWord.value,
+          code: searchCode.value,
           use_only_blank: onlyBlank.value,
           schedules: JSON.stringify(schedules.value),
         });
@@ -382,6 +400,7 @@ export default defineComponent({
         courses = await searchCourse(ports)(
           schedules.value,
           searchWord.value.split(/\s/),
+          searchCode.value.split(/\s/),
           _offset,
           limit,
           onlyBlank.value
@@ -482,6 +501,7 @@ export default defineComponent({
       schedules,
       search,
       searchBoxRef,
+      searchCode,
       searchResult,
       searchWord,
       selectedCourses,
@@ -503,9 +523,9 @@ export default defineComponent({
 }
 
 .main {
-  margin-top: $spacing-5;
+  margin-top: $spacing-3;
   &__search {
-    height: calc(#{$vh} - 16.2rem);
+    height: calc(#{$vh} - 15.4rem);
     padding: $spacing-3 $spacing-0 $spacing-0;
   }
   &__bottom {
@@ -523,13 +543,13 @@ export default defineComponent({
 .search {
   &__top {
     display: flex;
-    margin-bottom: $spacing-5;
+    margin-bottom: $spacing-3;
   }
   &__option {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: $spacing-7;
+    margin-bottom: $spacing-4;
   }
   &__result {
     height: calc(
@@ -545,9 +565,16 @@ export default defineComponent({
 }
 
 .top {
+  &__course-code {
+    flex: 1 0 10.2rem;
+    margin-right: $spacing-1;
+  }
   &__course-name {
-    width: 100%;
+    flex: 3 1 auto;
     margin-right: $spacing-2;
+  }
+  &__search-button {
+    margin-top: 2.8rem;
   }
 }
 

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -40,7 +40,11 @@
             />
           </div>
           <div class="option__accordion-toggle" @click="toggleOpen">
-            条件を指定する
+            条件
+            <span
+              :class="`accordion-toggle__conditions --${conditions.style}`"
+              >{{ conditions.label }}</span
+            >
             <span
               :class="{ 'material-icons': true, '--turned': isAccordionOpen }"
               >expand_more</span
@@ -239,6 +243,27 @@ export default defineComponent({
       schedules.value.splice(index, 1);
     };
 
+    /** condition */
+    const conditions = computed<{ style: "outline" | "filled"; label: string }>(
+      () => {
+        if (onlyBlank.value) return { style: "filled", label: "空きコマのみ" };
+        else if (
+          Object.values(schedules.value[0]).every((x) => x === "指定なし")
+        )
+          return { style: "outline", label: "未指定" };
+        else
+          return {
+            style: "filled",
+            label: schedules.value
+              .map(
+                (schedule) =>
+                  `${schedule.module}${schedule.day}${schedule.period}`
+              )
+              .join(","),
+          };
+      }
+    );
+
     /** result */
     const searchResult = ref<
       { course: Course; isSelected: boolean; isExpanded: boolean }[]
@@ -360,6 +385,7 @@ export default defineComponent({
       addSchedule,
       btnState,
       closeDuplicationModal,
+      conditions,
       courseToCard,
       duplicatedCourses,
       duplicationModal,
@@ -419,6 +445,7 @@ export default defineComponent({
     display: flex;
     align-items: center;
     justify-content: space-between;
+    margin-bottom: $spacing-7;
   }
   &__result {
     height: calc(#{$vh} - 26.6rem);
@@ -439,12 +466,32 @@ export default defineComponent({
   &__accordion-toggle {
     @include text-button;
     @include button-cursor;
+    display: flex;
+    align-items: center;
     .material-icons {
       margin-left: $spacing-1;
       transition: $transition-transform;
       &.--turned {
         transform: rotate(-180deg);
       }
+    }
+  }
+}
+
+.accordion-toggle {
+  &__conditions {
+    margin-left: $spacing-1;
+    padding: $spacing-1;
+    border: 0.1rem solid getColor(--color-primary-dull);
+    border-radius: $radius-1;
+    &.--outline {
+      color: getColor(--color-primary-dull);
+    }
+    &.--filled {
+      @include ellipsis;
+      max-width: 12rem;
+      background-color: getColor(--color-primary-dull);
+      color: getColor(--color-white);
     }
   }
 }

--- a/src/styles/_mixin.scss
+++ b/src/styles/_mixin.scss
@@ -188,6 +188,12 @@
   }
 }
 
+@mixin pc {
+  @media only screen and (min-height: variable.$pc-height) and(min-width: variable.$pc-width) {
+    @content;
+  }
+}
+
 @mixin landscape {
   @media screen and (min-width: 678px) and(orientation: landscape) {
     // 画面が横向きの場合

--- a/src/styles/_variable.scss
+++ b/src/styles/_variable.scss
@@ -186,3 +186,5 @@ $vh: calc(100vh - #{$safe-area-top});
 // Media Queries
 $pc-and-tab-height: 860px;
 $pc-and-tab-width: 429px;
+$pc-height: 860px;
+$pc-width: 1025px;

--- a/src/styles/_variable.scss
+++ b/src/styles/_variable.scss
@@ -45,7 +45,7 @@ $dark-theme-colors: (
   base: #1c222d,
   primary: #19c6c6,
   primary-light: #424c5a69,
-  primaryull: #4e7b8e,
+  primary-dull: #4e7b8e,
   text-main: #d4dae3,
   text-sub: #adb8bd,
   text-sub-light: #9ca6ad,

--- a/src/usecases/searchCourse.ts
+++ b/src/usecases/searchCourse.ts
@@ -103,6 +103,7 @@ const schedulesToTimetable = (
 export const searchCourse = (ports: Ports) => async (
   schedules: Schedule[],
   searchWords: string[],
+  searchCodes: string[],
   offset: number,
   limit: number,
   onlyBlank: boolean
@@ -115,6 +116,7 @@ export const searchCourse = (ports: Ports) => async (
         year,
         searchMode: onlyBlank ? "Contain" : "Cover", // TODO: ユーザが選択できるようにする
         keywords: searchWords,
+        codes: searchCodes,
         timetable: schedulesToTimetable(
           schedules.map(parseSchedules),
           onlyBlank,

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,3 +4,6 @@ export const isContainedIn = <T extends string>(
   text: string,
   set: T[]
 ): text is typeof set[number] => set.some((el) => el === text);
+
+export const flipSet = <T>(set: Set<T>, el: T) =>
+  set.has(el) ? set.delete(el) : set.add(el);


### PR DESCRIPTION
# 変更内容

1. 検索時の情報量を増やした
2. 現在の検索オプションを小さく表示するようにした
3. ページ内で選択した講義を保持できるように
4. 科目番号検索を実装

#464 ですが  2 で解決するとのことで実装しないという方向性になった気がするのですがいかがでしょうか？
#464 は空コマをタップしたさいの自動で検索講義のコマ指定範囲に気づかないということから立てられた issue ですが、2 の変更でその心配は不要になりましたので。


fix #496 
