### PR TITLE
重複検知時に store から取得する courses を年度指定できるように

### DIFF
--- a/src/pages/add/csv.vue
+++ b/src/pages/add/csv.vue
@@ -99,6 +99,7 @@ import { extractMessageOrDefault } from "~/usecases/error";
 import { getCoursesByCode } from "~/usecases/getCourseByCode";
 import { getCoursesIdByFile } from "~/usecases/readCSV";
 import { getDuplicatedCourses } from "~/usecases/getDuplicatedCourses";
+import { getYear } from "~/usecases/getYear";
 import { periodToString } from "~/usecases/periodToString";
 import { usePorts } from "~/usecases";
 import { useRouter } from "vue-router";
@@ -144,8 +145,10 @@ export default defineComponent({
 
     const addCourse = async (showWarning = true) => {
       if (btnState.value === "disabled") return;
+      const year = await getYear(ports);
       duplicatedCourses.value = getDuplicatedCourses(ports)(
-        loadedCourses.value.filter((v) => v.isSelected).map((v) => v.course)
+        loadedCourses.value.filter((v) => v.isSelected).map((v) => v.course),
+        year
       );
       if (showWarning && duplicatedCourses.value.length > 0) {
         openDuplicationModal();

--- a/src/pages/add/manual.vue
+++ b/src/pages/add/manual.vue
@@ -235,7 +235,8 @@ export default defineComponent({
       ]) as Required<RegisteredCourseWithoutID>;
 
       // 開講時限が重複しているかどうか？
-      if (showWarning && isCourseDuplicated(ports)(course)) {
+      const year = await getYear(ports);
+      if (showWarning && isCourseDuplicated(ports)(course, year)) {
         duplicatedCourses.value[0] = course;
         openDuplicationModal();
         return;

--- a/src/pages/add/search.vue
+++ b/src/pages/add/search.vue
@@ -154,6 +154,7 @@ import { defineComponent, ref, computed, ComponentPublicInstance } from "vue";
 import { displayToast } from "~/entities/toast";
 import { extractMessageOrDefault } from "~/usecases/error";
 import { getDuplicatedCourses } from "~/usecases/getDuplicatedCourses";
+import { getYear } from "~/usecases/getYear";
 import { periodToString } from "~/usecases/periodToString";
 import { Schedule } from "~/entities/schedule";
 import { searchCourse } from "~/usecases/searchCourse";
@@ -308,8 +309,10 @@ export default defineComponent({
 
     const addCourse = async (showWarning = true) => {
       if (btnState.value == "disabled") return;
+      const year = await getYear(ports);
       duplicatedCourses.value = getDuplicatedCourses(ports)(
-        searchResult.value.filter((v) => v.isSelected).map((v) => v.course)
+        searchResult.value.filter((v) => v.isSelected).map((v) => v.course),
+        year
       );
       if (showWarning && duplicatedCourses.value.length > 0) {
         openDuplicationModal();

--- a/src/store/getter.ts
+++ b/src/store/getter.ts
@@ -19,6 +19,11 @@ export const getters: GetterTree<GlobalState, GlobalState> = {
       []
     );
   },
+  coursesByYear: (state) => {
+    return (year: number) => {
+      return state.courses?.[year] ?? [];
+    };
+  },
   label: (state) => {
     return state.label;
   },

--- a/src/usecases/getDuplicatedCourses.ts
+++ b/src/usecases/getDuplicatedCourses.ts
@@ -14,11 +14,12 @@ import { Day, week } from "~/entities/day";
  * ただし「コマ」で表現できない日程は必ず重複しない
  */
 export const isSchedulesDuplicated = ({ store }: Ports) => (
-  targetSchedules: CourseSchedule[]
+  targetSchedules: CourseSchedule[],
+  year: number
 ): boolean => {
   return (
     targetSchedules?.some((targetSchedule) => {
-      return store.getters.courses.some((c: RegisteredCourse) => {
+      return store.getters.coursesByYear(year).some((c: RegisteredCourse) => {
         const registeredSchedules = c.schedules ?? c.course?.schedules;
         return registeredSchedules?.some(
           (s: CourseSchedule) =>
@@ -42,12 +43,13 @@ export const isSchedulesDuplicated = ({ store }: Ports) => (
 export const isCourseDuplicated = ({ store }: Ports) => <
   T extends Course | RegisteredCourseWithoutID
 >(
-  target: T
+  target: T,
+  year: number
 ): boolean => {
   if (target.schedules == undefined) {
     return false;
   }
-  return isSchedulesDuplicated({ store } as Ports)(target.schedules);
+  return isSchedulesDuplicated({ store } as Ports)(target.schedules, year);
 };
 
 /**
@@ -56,5 +58,7 @@ export const isCourseDuplicated = ({ store }: Ports) => <
 export const getDuplicatedCourses = ({ store }: Ports) => <
   T extends Course | RegisteredCourseWithoutID
 >(
-  targets: T[]
-): T[] => targets.filter((v) => isCourseDuplicated({ store } as Ports)(v));
+  targets: T[],
+  year: number
+): T[] =>
+  targets.filter((v) => isCourseDuplicated({ store } as Ports)(v, year));

--- a/src/usecases/searchCourse.ts
+++ b/src/usecases/searchCourse.ts
@@ -76,7 +76,8 @@ const periods: (keyof SearchCourseTimetableQueryPeriods)[] = [
 const schedulesToTimetable = (
   schedules: ParsedSchedule[],
   onlyBlank: boolean,
-  ports: Ports
+  ports: Ports,
+  year: number
 ): SearchCourseTimetableQuery | undefined => {
   let allTrue = true;
   const timetable = {} as SearchCourseTimetableQuery;
@@ -88,9 +89,10 @@ const schedulesToTimetable = (
         // とりあえず空白検索とドロップダウン検索は or で実装
         // HACK: backend の要望により timetable が全て true の場合 undedined を返す。
         const ret = onlyBlank
-          ? !isSchedulesDuplicated(ports)([
-              { module, day, period: parseInt(period), room: "" },
-            ])
+          ? !isSchedulesDuplicated(ports)(
+              [{ module, day, period: parseInt(period), room: "" }],
+              year
+            )
           : isWishinSchedules(schedules, module, day, parseInt(period));
         timetable[module]![day]![period] = ret;
         if (ret === false) allTrue = false;
@@ -118,7 +120,8 @@ export const searchCourse = (ports: Ports) => async (
         timetable: schedulesToTimetable(
           schedules.map(parseSchedules),
           onlyBlank,
-          ports
+          ports,
+          year
         ),
         offset,
         limit,


### PR DESCRIPTION
過去のすべての年度の授業と比較していたため重複していない授業でも重複モーダルが発生していました。（#514）

年度ごとに取得できるようにし解決しました。

fix #514 
