### PR TITLE
Add credit year

### DIFF
--- a/src/hooks/useCreditYear.ts
+++ b/src/hooks/useCreditYear.ts
@@ -1,0 +1,15 @@
+import { computed, ref } from "vue";
+
+const _creditYear = ref<number | undefined>(undefined);
+
+export const useCreditYear = () => {
+  const creditYear = computed(() => _creditYear.value);
+  const updateCreditYear = (year: number | undefined) => {
+    _creditYear.value = year;
+  };
+
+  return {
+    creditYear,
+    updateCreditYear,
+  };
+};

--- a/src/pages/credit/_id.vue
+++ b/src/pages/credit/_id.vue
@@ -56,6 +56,7 @@ import PageHeader from "~/components/PageHeader.vue";
 import { CreditCourseWithState } from "~/entities/course";
 import { DisplayTag, ALL_COURSES_ID, NEW_TAG_ID } from "~/entities/tag";
 import { displayToast } from "~/entities/toast";
+import { useCreditYear } from "~/hooks/useCreditYear";
 import { usePorts } from "~/usecases";
 import { createTag } from "~/usecases/createTag";
 import {
@@ -82,11 +83,11 @@ export default defineComponent({
     const route = useRoute();
     const router = useRouter();
 
+    const { creditYear } = useCreditYear();
+
     /**
-     * year === 0 の場合は すべての年度
      * tag === 'all' の場合は すべての授業
      */
-    const year = Number(route.query.year ?? 0);
     const tagId = route.params.id as string;
     const selectedTag: Tag | undefined =
       tagId === ALL_COURSES_ID ? undefined : await getTagById(ports)(tagId);
@@ -94,7 +95,10 @@ export default defineComponent({
       await router.push("/credit");
 
     const getRegisteredCourses = async (): Promise<RegisteredCourse[]> => {
-      const years = year === 0 ? [2019, 2020, 2021, 2022] : [year];
+      const years =
+        creditYear.value == undefined
+          ? [2019, 2020, 2021, 2022]
+          : [creditYear.value];
       const registeredCourses: RegisteredCourse[] = [];
       for (const y of years) {
         registeredCourses.push(...(await getCourseListByYear(ports)(y)));
@@ -244,7 +248,10 @@ export default defineComponent({
         .toFixed(1)
     );
     const info = computed(() => ({
-      year: year === 0 ? "すべての年度" : `${year}年度`,
+      year:
+        creditYear.value == undefined
+          ? "すべての年度"
+          : `${creditYear.value}年度`,
       tag:
         tagId === ALL_COURSES_ID
           ? "すべての授業 "

--- a/src/pages/credit/index.vue
+++ b/src/pages/credit/index.vue
@@ -12,10 +12,11 @@
       <template #title>単位数</template>
     </PageHeader>
     <Dropdown
-      v-model:selectedOption="selectedYear"
+      :selectedOption="selectedYear"
       :options="yearOptions"
       label="対象年度"
       :state="mode === 'default' ? 'default' : 'disabled'"
+      @update:selected-option="updateSelectedYear"
     ></Dropdown>
     <section class="tags">
       <div class="tags__header">
@@ -178,6 +179,7 @@ import TagListContent from "~/components/TagListContent.vue";
 import TextFieldSingleLine from "~/components/TextFieldSingleLine.vue";
 import { CreditTag, ALL_COURSES_ID, NEW_TAG_ID } from "~/entities/tag";
 import { displayToast } from "~/entities/toast";
+import { useCreditYear } from "~/hooks/useCreditYear";
 import { usePorts } from "~/usecases";
 import { changeTagOrders } from "~/usecases/changeTagOrders";
 import { createTag } from "~/usecases/createTag";
@@ -209,6 +211,8 @@ export default defineComponent({
       title: "Twin:te | 単位数",
     });
 
+    const { creditYear, updateCreditYear } = useCreditYear();
+
     const ports = usePorts();
     const router = useRouter();
 
@@ -220,9 +224,16 @@ export default defineComponent({
       "2020年度",
       "2019年度",
     ];
-    const selectedYear = ref<string>(yearOptions[0]);
+    const selectedYear = computed(() =>
+      creditYear.value == undefined ? "すべての年度" : `${creditYear.value}年度`
+    );
+    const updateSelectedYear = (year: string) => {
+      updateCreditYear(
+        year === "すべての年度" ? undefined : Number(year.slice(0, 4))
+      );
+    };
 
-    watch(selectedYear, async () => {
+    watch(selectedYear, async (year) => {
       await updateApiCourses();
       updateTags();
     });
@@ -341,15 +352,7 @@ export default defineComponent({
       }
     };
     const onClickTransitionBtn = (tag: CreditTag) => {
-      router.push({
-        path: `/credit/${tag.id}`,
-        query: {
-          year:
-            selectedYear.value === "すべての年度"
-              ? 0
-              : Number(selectedYear.value.slice(0, 4)),
-        },
-      });
+      router.push(`/credit/${tag.id}`);
     };
     const onClickAddBtn = () => {
       tags.value.push({ id: NEW_TAG_ID, name: "", credit: "0.0" });
@@ -400,6 +403,7 @@ export default defineComponent({
       router,
       yearOptions,
       selectedYear,
+      updateSelectedYear,
       mode,
       editingTagId,
       dragging,


### PR DESCRIPTION
単位数のページで用いる年度の情報を global state として管理しています。
これによりページ遷移が行われたとしても、年度が毎回`すべての年度`にリセットされることがなくなりました。

実装は[State Management](https://vuejs.org/guide/scaling-up/state-management.html)を参考に`composable`の形式で行いました。

<img width="364" alt="スクリーンショット 2022-04-09 0 43 29" src="https://user-images.githubusercontent.com/68944024/162476672-3989af1c-a2bf-45a7-8067-0028f3394664.png">

