### PR TITLE
use actions/setup-node in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14"
 
       - name: Use yarn global cache
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
         with:
           node-version: "14"
 
-      - uses: actions/setup-node@v3
+      - name: Use yarn global cache
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,10 @@ jobs:
         with:
           node-version: "14"
 
-      - name: Use cached node_modules
-        uses: actions/cache@v1
+      - uses: actions/setup-node@v3
         with:
-          path: node_modules
-          key: nodeModules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            nodeModules-
+          node-version: 16
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
Fixes #548 

yarn の global cache を使用するので特に一部のパッケージのみが更新された場合により高速に install ができると思います。

↓ actiion/setup-node で yarn の global cache を使用する事に関するドキュメントです
https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data