### PR TITLE
講義が登録直後に反映されないバグを修正

### DIFF
--- a/src/usecases/bulkAddCourseById.ts
+++ b/src/usecases/bulkAddCourseById.ts
@@ -22,8 +22,10 @@ export const bulkAddCourseById = (ports: Ports) => async (codes: string[]) => {
     });
 
   if (isValidStatus(status)) {
-    const courses = await getCourseListByYear(ports)(year);
-    store.commit("setCourses", { year, courses });
+    const cachedCourses = await getCourseListByYear(ports)(year);
+    const addedCourses = Array.isArray(body) ? body : [body];
+    const newCourses = [...cachedCourses, ...addedCourses];
+    store.commit("setCourses", { year, newCourses });
   } else {
     console.error(body);
     throw new NetworkAccessError(originalResponse);


### PR DESCRIPTION
Fixes: https://github.com/twin-te/twinte-front/issues/570

Issue のとおりです。本当は `setCourses` まわりとか色々整理するのがベストです。
しかしこの PR はあくまで #570 の対応のみがスコープなので、そこらへんの整理はしません。

そこらへんの整理をスコープ外とした理由は近日中にだされる #567 のバグを修正した PR で解決するためです。