### PR TITLE
連絡先メールアドレスを必須にし Twitter ID の入力を廃止

### DIFF
--- a/src/ui/components/TextFieldSingleLine.vue
+++ b/src/ui/components/TextFieldSingleLine.vue
@@ -19,6 +19,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ["update:modelValue", "enter-text-field", "close"],
   setup: (_, { emit }) => {
@@ -36,10 +40,15 @@ export default defineComponent({
   <div :class="{ 'text-field': true, [`text-field--${type}`]: true }">
     <div class="text-field__box">
       <input
-        class="text-field__input"
+        :class="{
+          'text-field': true,
+          'text-field__input': true,
+          '--disabled': disabled,
+        }"
         type="text"
         :value="modelValue"
         :placeholder="placeholder"
+        :disabled="disabled"
         @input="handleInput"
         @keydown.enter="$emit('enter-text-field')"
       />
@@ -104,6 +113,11 @@ export default defineComponent({
     color: getColor(--color-button-gray);
     font-size: 2rem;
     @include button-cursor;
+  }
+
+  &.--disabled {
+    opacity: 0.3;
+    box-shadow: $shadow-convex;
   }
 }
 </style>

--- a/src/ui/pages/feedback.vue
+++ b/src/ui/pages/feedback.vue
@@ -49,9 +49,15 @@
           <div class="feedback__note">
             より快適なサービスを提供するため開発チームより連絡をさせていただくことがあります。
           </div>
+          <div class="feedback__checkbox">
+            <CheckContent v-model:checked="allowReplies"
+              >運営からの返信を許可する</CheckContent
+            >
+          </div>
           <TextFieldSingleLine
             v-model="email"
             placeholder="xxx@example.com"
+            :disabled="!allowReplies"
           ></TextFieldSingleLine>
         </section>
       </div>
@@ -82,6 +88,7 @@ import {
   displayFeedbackTypes,
 } from "~/presentation/presenters/feedback";
 import Button from "~/ui/components/Button.vue";
+import CheckContent from "~/ui/components/CheckContent.vue";
 import Dropdown from "~/ui/components/Dropdown.vue";
 import IconButton from "~/ui/components/IconButton.vue";
 import InputButtonFile from "~/ui/components/InputButtonFile.vue";
@@ -104,6 +111,7 @@ const router = useRouter();
 const feedbackType = ref<FeedbackType>("Bug");
 const screenShot = ref<File>();
 const feedbackContent = ref("");
+const allowReplies = ref(true);
 const email = ref("");
 
 const updateSelectedOption = (option: DisplayFeedbackType) => {
@@ -122,7 +130,8 @@ const placeholder: Record<FeedbackType, string> = {
 const ButtonState = computed(() => {
   if (
     feedbackContent.value === "" ||
-    (feedbackType.value === "Contact" && email.value === "")
+    (feedbackType.value === "Contact" &&
+      (email.value === "" || !allowReplies.value))
   )
     return "disabled";
   return "default";
@@ -133,7 +142,7 @@ const onClickButton = async () => {
     type: feedbackType.value,
     screenShots: screenShot.value ? [screenShot.value] : [],
     content: feedbackContent.value,
-    email: email.value,
+    email: allowReplies.value ? email.value : "",
   })
     .then(() => {
       displayToast("フィードバックを送信しました。ありがとうございます。", {
@@ -181,6 +190,9 @@ const onClickButton = async () => {
   &__note {
     @include text-description-sub;
     margin: 1rem 0;
+  }
+  &__checkbox {
+    margin: $spacing-2 0;
   }
 }
 </style>

--- a/src/ui/pages/feedback.vue
+++ b/src/ui/pages/feedback.vue
@@ -44,15 +44,14 @@
             height="20rem"
           ></TextFieldMultilines>
         </section>
-        <section
-          v-if="['Bug', 'Contact'].includes(feedbackType)"
-          class="feedback__row"
-        >
+        <section class="feedback__row">
           <Label
             value="連絡先メールアドレス or Twitterアカウント"
-            :mandatory="feedbackType === 'Contact'"
+            mandatory
           ></Label>
-          <div class="feedback__note">{{ emailNote[feedbackType] }}</div>
+          <div class="feedback__note">
+            より快適なサービスを提供するため開発チームより連絡をさせていただくことがあります。
+          </div>
           <TextFieldSingleLine
             v-model="email"
             placeholder="xxx@example.com / @te_twin"
@@ -120,14 +119,6 @@ const placeholder: Record<FeedbackType, string> = {
   NewFeature:
     "例）学部生ですが、検索で大学院の授業ばかりでてきてしまうので大学院の授業を除外して検索する機能がほしいです。",
   Contact: "例）Twin:te の発音はツインテですか？トゥインテですか？",
-  Other: "",
-};
-
-const emailNote: Record<FeedbackType, string> = {
-  Bug:
-    "より詳しい原因解明のため開発チームから連絡を差し上げる場合がございます。ご協力いただける場合はメールアドレスまたはTwitterアカウントをご記入ください。",
-  NewFeature: "",
-  Contact: "返信用のメールアドレスまたはTwitterアカウントをご記入下さい。",
   Other: "",
 };
 

--- a/src/ui/pages/feedback.vue
+++ b/src/ui/pages/feedback.vue
@@ -45,16 +45,13 @@
           ></TextFieldMultilines>
         </section>
         <section class="feedback__row">
-          <Label
-            value="連絡先メールアドレス or Twitterアカウント"
-            mandatory
-          ></Label>
+          <Label value="連絡先メールアドレス" mandatory></Label>
           <div class="feedback__note">
             より快適なサービスを提供するため開発チームより連絡をさせていただくことがあります。
           </div>
           <TextFieldSingleLine
             v-model="email"
-            placeholder="xxx@example.com / @te_twin"
+            placeholder="xxx@example.com"
           ></TextFieldSingleLine>
         </section>
       </div>


### PR DESCRIPTION
## 概要

Resolves #578 
Resolves #582
Resolves #511

どれもフィードバックページに関する軽微な変更だったのでまとめて対処してしまいました。

## 変更点

1. 返信を許可するためのチェックボックスが追加される
    1. 許可するとメールアドレスを入力するフォームが avtive に、許可しないと disable になる
1. 連絡先から Twitter ID への言及が消える

### チェックボックスの挙動について

いくつか注意するべき挙動があります。この挙動でいいかご意見ください。

1. メールアドレスを入力後にチェックボックスを disable にすると、テキストフィールドに文字は残るが、送信時にメールアドレスが送信されない
当初は disable にした瞬間にメールアドレスの text field を空にしようかと思いました。しかし誤ってチェックボックスを押した場合に、フォームの中身が消えるのはストレスだな…と思ったので、この挙動にしました。

2. 「お問い合わせ」の場合はこのチェックボックスを OFF にすると、送信ボタンが disable になる

### スクリーンショット

チェックボックスを ON
![image](https://user-images.githubusercontent.com/45098934/197410716-50f9eb49-c678-475c-80b2-c3a8644e08ba.png)

チェックボックスを OFF
![image](https://user-images.githubusercontent.com/45098934/197410731-f6b145f0-8ca8-48a9-a1a1-183a26a64b59.png)


