### PR TITLE
初期表示時にもダークモードを適応するように

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,23 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <style>
+      .precedence-dark {
+        width: 100%;
+        height: 100vh;
+        background: linear-gradient(
+          158.17deg,
+          #0c101a -1.94%,
+          #202530 -1.93%,
+          #141821 102.24%
+        );
+        color: #626a76;
+      }
+    </style>
+    <script>
+      const isDarkMode = localStorage.getItem("darkMode") === "true";
+      if (isDarkMode) document.documentElement.classList.add("precedence-dark");
+    </script>
     <link rel="icon" href="/icon.png" />
     <meta
       name="viewport"

--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -9,7 +9,9 @@
       </Layout>
     </template>
     <template #fallback>
-      <div class="loading">now loading...</div>
+      <div class="loading">
+        <p class="loading__text">Now loading...</p>
+      </div>
     </template>
   </Suspense>
 </template>
@@ -65,7 +67,10 @@ onErrorCaptured((error) => {
 @import "~/ui/styles";
 
 .loading {
-  @include center-asolute;
-  opacity: 0.5;
+  @include center-flex;
+  width: 100%;
+  height: 100vh;
+  background: var(--base-liner);
+  color: var(--text-sub-light);
 }
 </style>


### PR DESCRIPTION
## 背景

Resolves #584 
Resolves #427 

## 変更点
見やすくするために Chrome の Developer Tools で通信速度に制限をかけて録画しています。

今まではページの読み込み時にダークモードが適応されませんでした。

<div>
    <video controls src="https://user-images.githubusercontent.com/45098934/196009680-f0451eff-7270-4813-a13c-8fb39974b13d.mp4"></video>
</div>

この変更によりページの読み込み時にダークモードが適応されます。
<div>
    <video controls src="https://user-images.githubusercontent.com/45098934/196009693-d81388c6-e0eb-4aab-9ff1-b4c9a4b24f7f.mp4"></video>
</div>

## 実装について

ページの読み込みには 2 段階あり、それぞれでダークモードが適応されるようにしました。

### 1. `index.html` の取得 ～ ローディング画面の表示
https://github.com/twin-te/twinte-front/commit/f932d35a77b534c95d61f8e5a3c85bdcff694da5  で実装しています。
ここの部分は `index.html` 単体で完結する必要があるので少々無理やりな実装になっています。

まず予め `.precedence-dark` にダークモードのスタイルを定義しておきます。ここでは SCSS 変数は使えないのでベタ書きです。
次に `useDark` が LocalStorage に保存している `darkMode` を参照し、ダークモードを適応するべきか判断します。`darkMode` は外向けに定義されている仕様ではないので、この手法が永遠に使える保証はありません。
ただ `darkMode` が定義されていなければ `null` が返ってくるだけなのでアプリの停止など致命的なバグに結びつく可能性は低いです。なので仕様が変わるリスクを受け入れつつも常時ダークモードを実現するほうがユーザにとって利が大きいと考え、この実装にしました。
なおこれらは HTML のレンダリング前に行われる必要があるので `<head>` 内に記述されています。



### 2. ローディング画面の表示中
https://github.com/twin-te/twinte-front/commit/1c8973b7aca24de6cb2423bfb7911952277f2d98 で実装しています。
これは単にローディング画面にダークモードを適応しただけです。

@KanadeNishizawa 
デザインを確認していただきたいです。