### PR TITLE
fix the way api course updates

### DIFF
--- a/src/infrastructure/api/converters/registeredCourse.ts
+++ b/src/infrastructure/api/converters/registeredCourse.ts
@@ -60,8 +60,12 @@ const updateApiCourseProp = <
     v2: Required<ApiType.RegisteredCourse>[P]
   ) => boolean
 ): void => {
-  if (apiCourse.course && compareFn(apiCourse.course[prop], newValue)) return;
-  apiCourse[prop] = newValue;
+  if (
+    prop in apiCourse ||
+    (apiCourse.course && !compareFn(apiCourse.course[prop], newValue))
+  ) {
+    apiCourse[prop] = newValue;
+  }
 };
 
 /**


### PR DESCRIPTION
## 経緯
[こちら](https://github.com/twin-te/twinte-front/pull/571#pullrequestreview-1150345429)のバグの原因を調査していたところ、apiのRegisteredCourseの更新方法が間違っていたことがわかったので修正しました。

## バグの症状
授業を編集したときに編集した講義情報が保存されない場合がある。