### PR TITLE
開発用のプロキシサーバを追加

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,9 @@
 # for localhost
 
 NODE_ENV=development
+
+# If you use a browser extension like CORS Unlocker, activate this.
 VITE_API_URL=https://app.twinte.net/api/v3
+
+# If you use the proxy server, activate this.
+# VITE_API_URL=http://localhost:4000/api/v3

--- a/devproxy/Dockerfile
+++ b/devproxy/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY proxy_nginx.conf /etc/nginx/conf.d/default.conf

--- a/devproxy/proxy_nginx.conf
+++ b/devproxy/proxy_nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 4000;
+    server_name localhost;
+
+    location /api/ {
+        proxy_pass https://app.twinte.net/api/;
+    }
+
+    location / {
+        proxy_pass http://localhost:3000;
+    }
+}

--- a/devproxy/readme.md
+++ b/devproxy/readme.md
@@ -1,0 +1,21 @@
+# 開発用 Proxy サーバ
+
+開発用の Proxy サーバです。  
+開発時に CORS の制限を回避するために使います。
+
+## 使用方法
+
+localhost:3000 で dev サーバを立てます。このとき `.env.development.local` などで `VITE_API_URL=http://localhost:4000/api/v3` を設定してください。
+
+```bash
+yarn dev
+```
+
+その後プロキシサーバを立てます
+
+```bash
+# Run this dev proxy
+cd devproxy
+docker build -t proxy-server .
+docker run --net=host proxy-server
+```


### PR DESCRIPTION
現状この方法だと認証ができないため Draft
自分が開発をするときは本番環境で取得した `twinte_session` Cookie を手動でコピーしていた。

## 背景

#601 での Service Worker の開発に必要になったため追加した。
現行の Readme に書いてある、拡張機能を用いた CORS エラーの回避方法はブラウザのページスクリプト内でのみ使えるので、それとは別のところで動いている Service Worker では使えない。

また拡張機能で CORS エラーを回避する方法は、拡張機能が使えるブラウザのみでしか使えない方法であり、また拡張機能の仕様変更に左右されてしまう。

さらに上記の拡張機能はブラウザのリクエストに介入して CORS ヘッダーを改竄しており、本番環境とことなる CORS ヘッダーとなるので、動作環境などで本番環境と差異がでる可能性がある。

したがって Service Worker の開発に限らず、拡張機能に依存しないで、本番環境となるべく近い動作する CORS エラーを回避できる手法がほしかった。

## 変更点

ローカルで立てるプロキシサーバを追加した。