### PR TITLE
Fix 特殊日課なのに通常日課になっている

### DIFF
--- a/src/domain/event.ts
+++ b/src/domain/event.ts
@@ -1,5 +1,6 @@
-import { Dayjs } from "dayjs";
-import { NormalDay } from "./day";
+import { Dayjs, isDayjs } from "dayjs";
+import { hasProperty, isContained } from "~/utils";
+import { isNormalDay, NormalDay } from "./day";
 
 export type NormalEventType = "PublicHoliday" | "Holiday" | "Exam" | "Other";
 
@@ -33,11 +34,36 @@ export const eventTypes: EventType[] = [
 export const isNormalEventType = (
   eventType: unknown
 ): eventType is NormalEventType => {
-  return eventType !== "SubstituteDay";
+  return isContained(eventType, eventTypes) && eventType !== "SubstituteDay";
 };
 
 export const isSubstituteEventType = (
   eventType: unknown
 ): eventType is SubstituteEventType => {
   return eventType === "SubstituteDay";
+};
+
+export const isNormalEvent = (event: object): event is NormalEvent => {
+  return (
+    hasProperty(event, "date", isDayjs) &&
+    hasProperty(event, "eventType", isNormalEventType) &&
+    hasProperty(
+      event,
+      "description",
+      (v: unknown): v is string => typeof v === "string"
+    )
+  );
+};
+
+export const isSubstituteEvent = (event: object): event is SubstituteEvent => {
+  return (
+    hasProperty(event, "date", isDayjs) &&
+    hasProperty(event, "eventType", isSubstituteEventType) &&
+    hasProperty(
+      event,
+      "description",
+      (v: unknown): v is string => typeof v === "string"
+    ) &&
+    hasProperty(event, "changeTo", isNormalDay)
+  );
 };

--- a/src/presentation/__tests__/eventToDisplay.test.ts
+++ b/src/presentation/__tests__/eventToDisplay.test.ts
@@ -1,0 +1,51 @@
+import dayjs from "dayjs";
+import { Event } from "~/domain/event";
+import { eventToDisplay } from "../presenters/event";
+
+describe(eventToDisplay.name, () => {
+  it("Test PublicHoliday", () => {
+    const event = {
+      date: dayjs("2021-07-23T00:00:00.000Z"),
+      description: "スポーツの日",
+      eventType: "PublicHoliday",
+    } as Event;
+    expect(eventToDisplay(event)).toBe("スポーツの日");
+  });
+
+  it("Test Holiday", () => {
+    const event = {
+      date: dayjs("2021-11-05T00:00:00.000Z"),
+      description: "学園祭",
+      eventType: "Holiday",
+    } as Event;
+    expect(eventToDisplay(event)).toBe("学園祭");
+  });
+
+  it("Test Exam", () => {
+    const event = {
+      date: dayjs("2021-05-19T00:00:00.000Z"),
+      description: "春A 期末試験",
+      eventType: "Exam",
+    } as Event;
+    expect(eventToDisplay(event)).toBe("春A 期末試験");
+  });
+
+  it("Test Other", () => {
+    const event = {
+      date: dayjs("2022-01-15T00:00:00.000Z"),
+      description: "大学入学共通テスト",
+      eventType: "Other",
+    } as Event;
+    expect(eventToDisplay(event)).toBe("大学入学共通テスト");
+  });
+
+  it("Test SubstituteDay", () => {
+    const event = {
+      date: dayjs("2021-07-22T00:00:00.000Z"),
+      description: "",
+      eventType: "SubstituteDay",
+      changeTo: "Fri",
+    } as Event;
+    expect(eventToDisplay(event)).toBe("金曜日課");
+  });
+});

--- a/src/presentation/presenters/event.ts
+++ b/src/presentation/presenters/event.ts
@@ -1,0 +1,8 @@
+import { Event, isNormalEvent } from "~/domain/event";
+import { normalDayMap } from "./day";
+
+export const eventToDisplay = (event: Event): string => {
+  return isNormalEvent(event)
+    ? event.description
+    : `${normalDayMap[event.changeTo]}曜日課`;
+};

--- a/src/presentation/viewmodels/event.ts
+++ b/src/presentation/viewmodels/event.ts
@@ -1,0 +1,3 @@
+export type DisplayNormalEvent = "通常日課";
+
+export const displayNormalEvent: DisplayNormalEvent = "通常日課";

--- a/src/ui/components/PageHeader.vue
+++ b/src/ui/components/PageHeader.vue
@@ -116,6 +116,7 @@ export default defineComponent({
     top: 0;
   }
   &__calendar {
+    width: calc(50% - 4.95rem + 0.4rem - 2rem);
     position: absolute;
     right: 0;
     top: 0;
@@ -127,6 +128,8 @@ export default defineComponent({
     font-weight: bold;
   }
   &__schedule {
+    overflow: scroll;
+    white-space: nowrap;
     padding-top: 0.2rem;
     color: getColor(--color-text-sub);
     font-size: $font-small;

--- a/src/ui/pages/index.vue
+++ b/src/ui/pages/index.vue
@@ -267,6 +267,7 @@ import PageHeader from "~/ui/components/PageHeader.vue";
 import Popup from "~/ui/components/Popup.vue";
 import PopupContent from "~/ui/components/PopupContent.vue";
 import ToggleButton from "~/ui/components/ToggleButton.vue";
+import { getEvent, setEvent } from "~/ui/store/event";
 import { useSwitch } from "../hooks/useSwitch";
 import { toggleCourseType, setModule } from "../store";
 import { getCoursesByYear, setCoursesByYear } from "../store/course";
@@ -308,9 +309,11 @@ const module = await getModule();
 const currentModule: BaseModule = await getCurrentModule();
 
 /** page header */
+await setEvent();
+const event = getEvent();
 const today = dayjs();
 const calendar: PageHeaderCalendar = {
-  schedule: "通常日課",
+  schedule: event.value,
   month: today.month() + 1,
   day: today.date(),
   week: normalDayMap[normalDays[(today.day() + 6) % 7]],

--- a/src/ui/store/event.ts
+++ b/src/ui/store/event.ts
@@ -1,0 +1,26 @@
+import dayjs from "dayjs";
+import { computed, ref } from "vue";
+import { usePorts } from "~/adapter";
+import UseCase from "~/application/usecases";
+import { isResultError } from "~/domain/error";
+import { eventToDisplay } from "~/presentation/presenters/event";
+import { displayNormalEvent } from "~/presentation/viewmodels/event";
+import { deepCopy } from "~/utils";
+
+// state
+const event = ref<string>(displayNormalEvent);
+
+// getter
+export const getEvent = () => {
+  return computed(() => deepCopy(event.value));
+};
+
+// action
+const ports = usePorts();
+
+export const setEvent = async () => {
+  const result = await UseCase.getEventByDate(ports)(dayjs());
+  if (isResultError(result)) throw result;
+  if (result != undefined) event.value = eventToDisplay(result);
+  else event.value = displayNormalEvent;
+};


### PR DESCRIPTION
Resolve #599 

「通常日課」のところをイベント毎に表示が変わるように修正しました。
はみ出してしまう時はスクロールで対応しています。

![スクリーンショット 2022-11-12 1 42 44](https://user-images.githubusercontent.com/68944024/201388561-cab32162-934c-4f1f-a0d5-ad5a94ff42d8.png)

![スクリーンショット 2022-11-12 1 43 22](https://user-images.githubusercontent.com/68944024/201388564-2d4d97ab-ff46-4dcc-8a68-48582dcf7c14.png)

![スクリーンショット 2022-11-12 1 43 32](https://user-images.githubusercontent.com/68944024/201388567-fe29754e-abdf-4923-9e5b-a8cec0b9c056.png)

![スクリーンショット 2022-11-12 1 44 02](https://user-images.githubusercontent.com/68944024/201388568-c0520355-f08a-4488-b416-6eae2e2bdae8.png)
