### PR TITLE
iOS でローディングが崩れないように修正

### DIFF
--- a/src/ui/components/IconButton.vue
+++ b/src/ui/components/IconButton.vue
@@ -52,7 +52,24 @@ export default defineComponent({
       emit("click", e);
     };
 
-    return { handleClick };
+    const getButtonWidthPixel = () => {
+      const documentFontSize = parseFloat(
+        getComputedStyle(document.documentElement).fontSize
+      );
+
+      switch (props.size) {
+        case "small":
+          return 2.8 * documentFontSize;
+        case "medium":
+          return 3.3 * documentFontSize;
+        case "large":
+          return 4 * documentFontSize;
+        default:
+          return 3.3 * documentFontSize;
+      }
+    };
+
+    return { handleClick, getButtonWidthPixel };
   },
 });
 </script>
@@ -68,7 +85,7 @@ export default defineComponent({
     @click="handleClick"
     @keyup.enter="$emit('click', $event)"
   >
-    <Loader v-if="loading" size="100%" />
+    <Loader v-if="loading" :size="getButtonWidthPixel() / 2" />
     <span v-else class="material-icons">{{ iconName }}</span>
     <slot />
   </button>

--- a/src/ui/components/Loader.vue
+++ b/src/ui/components/Loader.vue
@@ -1,74 +1,101 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
-type Props = {
-  size: string;
-};
-
 export default defineComponent({
   props: {
     size: {
-      type: String,
-      default: "100%",
+      // size is loader's width and height pixel included dots
+      type: Number,
+      default: 20,
     },
-  },
-  setup(props: Props) {
-    return {
-      props,
-    };
   },
 });
 </script>
 
 <template>
-  <div class="loader" :style="{ fontSize: `calc(${size}/8)` }" />
+  <div class="loader" />
 </template>
 
 <style lang="scss" scoped>
 @import "~/ui/styles";
 
+$redius-1: calc(var(--size) / 8 * 3);
+$redius-2: calc(var(--size) / 8 * 2);
+$redius-3: 0;
+
+$spread-1: calc(var(--size) / 8 * 0.2);
+$spread-2: 0;
+$spread-3: calc(var(--size) / 8 * -1);
+
+@function box-shadow($shift) {
+  // prettier-ignore
+  $result: (
+      ($redius-3               calc(-1 * #{$redius-1}) 0),
+      ($redius-2               calc(-1 * #{$redius-2}) 0),
+      ($redius-1               $redius-3               0),
+      ($redius-2               $redius-2               0),      
+      ($redius-3               $redius-1               0),
+      (calc(-1 * #{$redius-2}) $redius-2               0),
+      (calc(-1 * #{$redius-1}) $redius-3               0),
+      (calc(-1 * #{$redius-2}) calc(-1 * #{$redius-2}) 0),
+  );
+
+  $spreads: (
+    $spread-1,
+    $spread-2,
+    $spread-3,
+    $spread-3,
+    $spread-3,
+    $spread-3,
+    $spread-3,
+    $spread-2
+  );
+
+  @for $i from 1 through length($result) {
+    $j: ((($i - 1) - $shift) % length($result)) + 1;
+    $new-box-shadow: append(nth($result, $i), nth($spreads, $j), "space");
+    $result: set-nth($result, $i, $new-box-shadow);
+  }
+
+  @return $result;
+}
+
 .loader {
+  --size: v-bind(`${size}px`);
   color: var(--color--text-main);
-  margin: 3em;
-  width: 1em;
-  height: 1em;
+  margin: $redius-1;
+  width: calc(var(--size) / 8);
+  height: calc(var(--size) / 8);
   border-radius: 50%;
-  animation: load4 1.3s infinite linear;
+  animation: loading 1.3s infinite linear;
   transform: translateZ(0);
 }
-@keyframes load4 {
+
+@keyframes loading {
   0%,
   100% {
-    box-shadow: 0 -3em 0 0.2em, 2em -2em 0 0em, 3em 0 0 -1em, 2em 2em 0 -1em,
-      0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 0;
+    box-shadow: box-shadow(0);
   }
   12.5% {
-    box-shadow: 0 -3em 0 0, 2em -2em 0 0.2em, 3em 0 0 0, 2em 2em 0 -1em,
-      0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+    box-shadow: box-shadow(1);
   }
   25% {
-    box-shadow: 0 -3em 0 -0.5em, 2em -2em 0 0, 3em 0 0 0.2em, 2em 2em 0 0,
-      0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+    box-shadow: box-shadow(2);
   }
   37.5% {
-    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 0, 2em 2em 0 0.2em,
-      0 3em 0 0em, -2em 2em 0 -1em, -3em 0em 0 -1em, -2em -2em 0 -1em;
+    box-shadow: box-shadow(3);
   }
   50% {
-    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 0em,
-      0 3em 0 0.2em, -2em 2em 0 0, -3em 0em 0 -1em, -2em -2em 0 -1em;
+    box-shadow: box-shadow(4);
   }
   62.5% {
-    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em,
-      0 3em 0 0, -2em 2em 0 0.2em, -3em 0 0 0, -2em -2em 0 -1em;
+    box-shadow: box-shadow(5);
   }
   75% {
-    box-shadow: 0em -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 -1em, 2em 2em 0 -1em,
-      0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0.2em, -2em -2em 0 0;
+    box-shadow: box-shadow(6);
   }
   87.5% {
-    box-shadow: 0em -3em 0 0, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em,
-      0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0, -2em -2em 0 0.2em;
+    box-shadow: box-shadow(7);
   }
 }
 </style>


### PR DESCRIPTION
## 背景

Resolves #498 
現状 Loader (くるくるまわるやつ) のサイズは `em` で指定しているが、これが Safari では予想外の挙動をし、#498 のようなバグが発生している

`em` を使用している理由は `font-size` 経由で動的に大きさを変更するため

## 変更

`font-size` と `em` を用いた方法は前述の通り問題が発生するので、`v-bind()` を用いた方法に変更した。
また今までは `Loader` の `size` Props が何を指しているのかわかりにくかったため、`size` を `Loader` の周囲のドットを含めた縦横のピクセル数に変更した。

それに伴い、`Loader` を使用する `Button` 側で、`Loader` の大きさを決めるロジックを追加した。

## 動作確認

MacOS の Safari においてスタイルが崩れていないことを確認

## デザイン

@KanadeNishizawa 
今回の変更で微妙にデザインが変更されたので確認していただきたいです。
デザインを変えるつもりはなかったのですが、大きさの計算ロジックが変わったので、微妙に変わってしまいました。

※~~わかりにくいので、↓ の [Vercel の Preview](https://twinte-front-git-fix-loading-style-twin-te.vercel.app/) などで確認いただくのが良いです。~~
Safari からの Vercel プレビューは現状サインインがうまくいかないようですね…

いままで
![image](https://user-images.githubusercontent.com/45098934/208253888-0313fcb7-737f-4a08-a071-aa5ed44dfe18.png)

今回
![image](https://user-images.githubusercontent.com/45098934/208253895-f1ea81ae-ca13-4c1f-8251-320b470883af.png)
