### PR TITLE
API 呼び出しの `try` の範囲を狭める

### DIFF
--- a/src/infrastructure/api/index.ts
+++ b/src/infrastructure/api/index.ts
@@ -81,24 +81,25 @@ export class Api {
   ): Promise<
     CR | ApiFailedStatueToError[FS] | InternalServerError | NetworkError | CE
   > {
+    let result: ApiRespoinse<AR, SS | FS>;
+
     try {
-      const {
-        body,
-        originalResponse,
-        status,
-      }: ApiRespoinse<AR, SS | FS> = await api(this.#client);
-
-      if (isContained(status, successStatusList)) {
-        return callback(body);
-      }
-
-      if (isContained(status, failedStatusList)) {
-        return this.#handleApiFailedStatus(status, originalResponse);
-      }
-
-      return new InternalServerError(`Invalid Status : ${status}`);
+      result = await api(this.#client);
     } catch {
+      // This dose not catch Error arising from HTTP Response error because of the Axios validateStatus setting.
       return new NetworkError();
     }
+
+    const { body, originalResponse, status } = result;
+
+    if (isContained(status, successStatusList)) {
+      return callback(body);
+    }
+
+    if (isContained(status, failedStatusList)) {
+      return this.#handleApiFailedStatus(status, originalResponse);
+    }
+
+    return new InternalServerError(`Invalid Status : ${status}`);
   }
 }


### PR DESCRIPTION
## 背景

以下のコメントの通りです。
Resolves #585 

補足
他にも`try`が大きすぎるところはありますが、特にここは大きかったので修正しました。
これを修正しないと、API 呼び出しの部分のコードで発生したなんらかのエラーはすべて`NetworkError`になってしまいます。
その場合 #593 で Sentry を導入しても、プロダクトの改善が難しくなってしまうので、取り急ぎここの部分だけ修正しました。

## 変更

`try` の範囲を狭めました。