### PR TITLE
V2 の Service Workers の削除処理を削除

### DIFF
--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -32,15 +32,6 @@ setSetting();
 
 const router = useRouter();
 
-/** unregister service worker (v2) */
-onMounted(() => {
-  navigator.serviceWorker.getRegistrations().then(function (registrations) {
-    for (let registration of registrations) {
-      registration.unregister();
-    }
-  });
-});
-
 /** error */
 const errorMessage = ref("");
 


### PR DESCRIPTION
## 背景

Resolves #612 

#612 にあるように V2 の Service Worker の削除処理でエラーが出ている。原因の推測は #612 に書いた。
しかしそもそも V3 が公開されてから 1 年半経過したので、このコードはもはや不要と考えた。 

V2 を開いてから一度も V3 を開いていないユーザがいるという極小の可能性への配慮と、すべてのユーザが無駄に `registration.unregister();` の処理を走らせることによるコストを天秤にかけた結果、削除したほうがいいと判断した。

## 変更

V2 の Service Workers の削除処理を削除する。