### PR TITLE
Lint の Warning を修正、無効化

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,6 +14,7 @@ module.exports = {
     },
   },
   ignorePatterns: "**/*.js",
+  parser: "vue-eslint-parser",
   rules: {
     "vue/attribute-hyphenation": 0,
     "import/order": [

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "typescript": "^4.6.2",
     "vite": "2.1.4",
     "vite-plugin-fonts": "^0.3.0",
-    "vue-eslint-parser": "7.6.0",
+    "vue-eslint-parser": "9.1.0",
     "vue-tsc": "^0.33.2"
   }
 }

--- a/src/infrastructure/api/index.ts
+++ b/src/infrastructure/api/index.ts
@@ -1,6 +1,6 @@
 import axiosClient from "@aspida/axios";
 import axios from "axios";
-import qs from "qs";
+import { stringify } from "qs";
 import {
   InternalServerError,
   NetworkError,
@@ -39,7 +39,7 @@ export class Api {
     this.#client = createApiInstance(
       axiosClient(axios, {
         baseURL,
-        paramsSerializer: (r: unknown) => qs.stringify(r),
+        paramsSerializer: (r: unknown) => stringify(r),
         validateStatus: () => true,
         withCredentials: true,
       })

--- a/src/infrastructure/firebase/index.ts
+++ b/src/infrastructure/firebase/index.ts
@@ -10,6 +10,8 @@ const firebaseConfig = {
   messagingSenderId: "506135788576",
   appId: "1:506135788576:web:e6e2df4eff16a20e8b9045",
 };
+
+// eslint-disable-next-line import/no-named-as-default-member
 firebase.initializeApp(firebaseConfig);
 
 export class Firebase {
@@ -27,6 +29,7 @@ export class Firebase {
     screenshots: File[],
     userId: string
   ): Promise<string[] | NetworkError | InternalServerError> {
+    // eslint-disable-next-line import/no-named-as-default-member
     const storageRef = firebase.storage().ref();
     const now = new Date();
 

--- a/src/ui/components/Button.vue
+++ b/src/ui/components/Button.vue
@@ -44,7 +44,8 @@ export default defineComponent({
   setup: (props: Props, { emit }) => {
     const isActive = ref(false);
 
-    const handleClick = (e: any) => {
+    const handleClick = (e: MouseEvent) => {
+      if (!(e.target instanceof HTMLButtonElement)) return;
       if (props.state === "disabled") return;
       isActive.value = props.pauseActiveStyle && !isActive.value;
       emit("click", e.target.value);

--- a/src/ui/components/NewsBox.vue
+++ b/src/ui/components/NewsBox.vue
@@ -24,6 +24,8 @@ export default defineComponent({
   <div class="news-box">
     <div class="news-box__publication-date">{{ publicationDate }}</div>
     <div class="news-box__title">{{ title }}</div>
+    <!-- `content` is a reliable value, because it is provided by twin:te operator -->
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div class="news-box__content" v-html="content"></div>
   </div>
 </template>

--- a/src/ui/components/ScheduleEditer.vue
+++ b/src/ui/components/ScheduleEditer.vue
@@ -48,8 +48,11 @@ export default defineComponent({
     },
   },
   emits: {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     "update:schedules": (index: number, schedule: EditableSchedule) => true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     "click-add-button": () => true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     "click-remove-button": (index: number) => true,
   },
   setup(_, { emit }) {

--- a/src/ui/pages/add/manual.vue
+++ b/src/ui/pages/add/manual.vue
@@ -158,7 +158,6 @@ import { addCustomizedCourse } from "~/ui/store/course";
 import { getApplicableYear, setApplicableYear } from "~/ui/store/year";
 import type { RegisteredCourse } from "~/domain/course";
 import type { Room } from "~/domain/room";
-import type { DisplaySchedule } from "~/presentation/viewmodels/schedule";
 
 const ports = usePorts();
 const router = useRouter();

--- a/src/ui/pages/add/search.vue
+++ b/src/ui/pages/add/search.vue
@@ -309,12 +309,7 @@ const keyword = ref("");
 const [onlyBlank, toggleOnlyBlank] = useToggle(false);
 
 /** accordion */
-const [
-  isAccordionOpen,
-  openAccordion,
-  closeAccordion,
-  toggleAccordion,
-] = useSwitch(false);
+const [isAccordionOpen, , closeAccordion, toggleAccordion] = useSwitch(false);
 
 const conditions = computed<{ style: "outline" | "filled"; label: string }>(
   () => {

--- a/src/ui/pages/course/_id/edit.vue
+++ b/src/ui/pages/course/_id/edit.vue
@@ -142,7 +142,6 @@ import TextFieldSingleLine from "~/ui/components/TextFieldSingleLine.vue";
 import { useSwitch } from "~/ui/hooks/useSwitch";
 import { getCourseById, setCourseById, updateCourse } from "~/ui/store/course";
 import type { RegisteredCourse } from "~/domain/course";
-import type { DisplaySchedule } from "~/presentation/viewmodels/schedule";
 
 const route = useRoute();
 const router = useRouter();

--- a/src/ui/pages/course/_id/index.vue
+++ b/src/ui/pages/course/_id/index.vue
@@ -283,9 +283,7 @@ const onClickDeleteCourseButton = async () => {
 };
 
 /** popup */
-const [isVisiblePopup, openPopup, closePopup, toggleShowPopup] = useSwitch(
-  false
-);
+const [isVisiblePopup, , closePopup, toggleShowPopup] = useSwitch(false);
 
 const popupContents: {
   onClick: () => void;

--- a/src/ui/pages/index.vue
+++ b/src/ui/pages/index.vue
@@ -320,7 +320,7 @@ const calendar: PageHeaderCalendar = {
 };
 
 /** popup */
-const [isPopupVisible, openPopup, closePopup, togglePopup] = useSwitch(false);
+const [isPopupVisible, , closePopup, togglePopup] = useSwitch(false);
 const onClickPopup = (baseModule: BaseModule) => {
   setModule(baseModule);
   closePopup();
@@ -403,7 +403,7 @@ const onClickCourseTile = async (
 await setNews();
 const unreadNews = getUnreadNews();
 
-const [isNewsModalVisible, openNewsModal, closeNewsModal] = useSwitch(
+const [isNewsModalVisible, , closeNewsModal] = useSwitch(
   unreadNews.value.length > 0
 );
 

--- a/src/ui/templates/Layout.vue
+++ b/src/ui/templates/Layout.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useBrowserLocation } from "@vueuse/core";
 import { watch } from "vue";
 import Button from "~/ui/components/Button.vue";
 import GrayFilter from "~/ui/components/GrayFilter.vue";
@@ -11,8 +10,6 @@ import { isVisibleSidebar, closeSidebar } from "~/ui/store/sidebar";
 import { deleteToast, getToasts } from "~/ui/store/toast";
 import Sidebar from "./Sidebar.vue";
 
-const location = useBrowserLocation();
-
 /** auth state */
 const authState = getAuthState();
 await setAuthState();
@@ -20,9 +17,9 @@ await setAuthState();
 /** welcome modal */
 const [
   isVisibleWelcomeModal,
-  openWelcomeModal,
+  ,
   closeWelcomeModal,
-  toggleWelcomeModal,
+  ,
   setWelcomeModal,
 ] = useSwitch(false);
 watch(

--- a/src/ui/templates/Sidebar.vue
+++ b/src/ui/templates/Sidebar.vue
@@ -40,7 +40,7 @@ import { getApplicableYear } from "~/ui/store/year";
 import { isiOS, isMobile } from "~/ui/ua";
 import { getLogoutUrl, openUrl } from "~/ui/url";
 
-const props = defineProps<{
+defineProps<{
   isLogin: boolean;
 }>();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,7 +4016,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.2.0, acorn-jsx@^5.3.1:
+acorn-jsx@^5.2.0, acorn-jsx@^5.3.1, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -5688,7 +5688,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.2:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.2.0, debug@^4.3.2:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -5702,7 +5702,7 @@ debug@^3.0.0, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.4:
+debug@^4.1.1, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -6365,7 +6365,7 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -6373,7 +6373,7 @@ eslint-scope@^5.0.0, eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.0.0:
+eslint-scope@^7.0.0, eslint-scope@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
   integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
@@ -6478,6 +6478,15 @@ espree@^9.0.0:
   dependencies:
     acorn "^8.7.0"
     acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^3.3.0"
+
+espree@^9.3.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz#51d6092615567a2c2cff7833445e37c28c0065bd"
+  integrity sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.3.0"
 
 esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
@@ -11384,6 +11393,13 @@ semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.6:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.2:
   version "0.17.2"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.2.tgz#926622f76601c41808012c8bf1688fe3906f7820"
@@ -12885,17 +12901,18 @@ vue-docgen-loader@^1.5.0:
     loader-utils "^1.2.3"
     querystring "^0.2.0"
 
-vue-eslint-parser@7.6.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-7.6.0.tgz#01ea1a2932f581ff244336565d712801f8f72561"
-  integrity sha512-QXxqH8ZevBrtiZMZK0LpwaMfevQi9UL7lY6Kcp+ogWHC88AuwUPwwCIzkOUc1LR4XsYAt/F9yHXAB/QoD17QXA==
+vue-eslint-parser@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-9.1.0.tgz#0e121d1bb29bd10763c83e3cc583ee03434a9dd5"
+  integrity sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==
   dependencies:
-    debug "^4.1.1"
-    eslint-scope "^5.0.0"
-    eslint-visitor-keys "^1.1.0"
-    espree "^6.2.1"
+    debug "^4.3.4"
+    eslint-scope "^7.1.1"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.1"
     esquery "^1.4.0"
-    lodash "^4.17.15"
+    lodash "^4.17.21"
+    semver "^7.3.6"
 
 vue-eslint-parser@^7.6.0:
   version "7.11.0"


### PR DESCRIPTION
## 背景

Lint の Wanring が大量に発生していた。
その結果、大量の既存エラーに埋もれてしまい手元や GitHub の PR 上での Lint Warning に注意を払わなくなってしまい、LInter の使用が形骸化してしまった。

## 変更点

Lint Warning を修正した。
また一部修正できないものは Lint を無効化することで対処した。

以下コメントで意図を記載する。
コミットメッセージにも最低限の意図を書いた。