### PR TITLE
Fix import pageの年度情報で表示年度を利用する

### DIFF
--- a/src/repositories/production/CourseRepository.ts
+++ b/src/repositories/production/CourseRepository.ts
@@ -88,6 +88,7 @@ export class CourseRepository implements ICourseRepository {
   > {
     const yearToCodes = inputData.reduce<Record<number, string[]>>(
       (ret, { year, code }) => {
+        if (ret[year] === undefined) ret[year] = [];
         ret[year].push(code);
         return ret;
       },


### PR DESCRIPTION
# 何をしたか

- #615 の修正
- yearはパスパラメータではなく表示年度から取得する
- CourseRepositoryが自分の環境だとエラー出て、ホンマか？って思いながら初期化処理追加した 32e643541c688da17accf6ecc6233c3c6eef8326

# screenshot

<img width="506" alt="image" src="https://user-images.githubusercontent.com/39324739/207257644-931f56b0-c29e-4ca5-93ff-e616348d51b0.png">
