### PR TITLE
CardCourse の詳細が開かないバグを修正

### DIFF
--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { onErrorCaptured, onMounted, ref } from "vue";
+import { onErrorCaptured, ref } from "vue";
 import { useRouter } from "vue-router";
 import {
   InternalServerError,

--- a/src/ui/pages/add/csv.vue
+++ b/src/ui/pages/add/csv.vue
@@ -28,6 +28,8 @@
           :key="result.course.id"
           :isChecked="result.selected"
           :course="result.course"
+          :isExpanded="result.expanded"
+          @click="onClickCard(result.course.id)"
           @click-checkbox="result.selected = !result.selected"
         >
         </CardCourse>
@@ -90,7 +92,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, shallowReactive } from "vue";
+import { ref, computed, reactive } from "vue";
 import { useRouter } from "vue-router";
 import { usePorts } from "~/adapter";
 import Usecase from "~/application/usecases";
@@ -121,11 +123,18 @@ type LoadedResult = {
   course: DisplayCourse;
   schedules: Schedule[];
   selected: boolean;
+  expanded: boolean;
 };
-const loadedResults = shallowReactive<LoadedResult[]>([]);
+const loadedResults = reactive<LoadedResult[]>([]);
 const selectedResults = computed(() =>
   loadedResults.filter(({ selected }) => selected)
 );
+
+const onClickCard = (courseId: string) => {
+  const course = loadedResults.find((result) => result.course.id === courseId);
+  if (!course) return;
+  course.expanded = !course.expanded; 
+};
 
 type Risyu = {
   type: "risyu";
@@ -223,6 +232,7 @@ const loadCourses = async (file: File) => {
       course: courseToDisplay(course),
       schedules: course.schedules,
       selected: true,
+      expanded: false,
     }))
   );
 

--- a/src/ui/pages/add/csv.vue
+++ b/src/ui/pages/add/csv.vue
@@ -133,7 +133,7 @@ const selectedResults = computed(() =>
 const onClickCard = (courseId: string) => {
   const course = loadedResults.find((result) => result.course.id === courseId);
   if (!course) return;
-  course.expanded = !course.expanded; 
+  course.expanded = !course.expanded;
 };
 
 type Risyu = {

--- a/src/ui/pages/add/search.vue
+++ b/src/ui/pages/add/search.vue
@@ -447,7 +447,6 @@ const onClickCheckbox = (searchResult: SearchResult) => {
 };
 
 const onClickCard = (id: string) => {
-  if (detailed.value) return;
   courseIdToExpanded[id] = !courseIdToExpanded[id];
 };
 


### PR DESCRIPTION
## 背景

Fixes #592 
Fixes #569 

## 変更

検索結果の CardCourse の詳細が開かないバグを修正
CSV Import の CardCourse の詳細が開かないバグを修正
（あまりよくはないがついでに）不要な変数を削除

## 動作確認

検索結果の CardCourse の詳細が開くことを確認
![image](https://user-images.githubusercontent.com/45098934/208241020-b6c55468-ef26-4f92-90a1-9c93370a778e.png)


CSV import で CardCourse が開くことを確認
![image](https://user-images.githubusercontent.com/45098934/208240979-139243c4-45f3-4393-a0d1-5e879116d182.png)

