### PR TITLE
外部からの授業インポート時に発生するエラーを修正

### DIFF
--- a/src/ui/pages/import.vue
+++ b/src/ui/pages/import.vue
@@ -14,7 +14,7 @@
       <template #title>授業のインポート</template>
     </PageHeader>
     <div class="main">
-      <section ref="importBoxRef" key="result" class="main__result">
+      <section key="result" class="main__result">
         <Card v-show="courseResults.length > 0">
           <div
             v-for="(result, i) in courseResults"


### PR DESCRIPTION
## 背景

Fixes #620 

上記 Issue にあるように、現在のバージョンだと外部（KdB もどきなど）から授業をインポートするさいに以下のようなエラーが生じます。

![image](https://user-images.githubusercontent.com/45098934/208486214-0ab110b0-f918-43ea-a428-00ff25103471.png)

このエラーは `importBoxRef` が`<template></template>` 内に定義されているが、`<script></script>`内では定義されていないときに発生するものです。

なお余談ですが、このエラーは`yarn dev`では再現せず、`yarn build` で初めて再現するという見落としがちなエラーだったりします（）

## 変更

不要な `ref="importBoxRef"` を削除しました。
これは https://github.com/twin-te/twinte-front/pull/529 で加えられたコードです。
#529 で言及されているように、この PR は検索ページの実装を移植したものです。
そのため[検索ページの`serachBoxRef`](https://github.com/twin-te/twinte-front/blob/e2c8a60a6d9a6d28a67a50b0f3a2a5b2b484f829/src/ui/pages/add/search.vue#L93)も誤って移植されたのだと思います。

## 動作確認

`yarn build` して KdB もどきから授業がインポートできることを確認。
![image](https://user-images.githubusercontent.com/45098934/208487158-91b4ebf3-073f-42ec-aeae-462655091820.png)



