### PR TITLE
Fix course order in /credit/_id page

### DIFF
--- a/src/ui/pages/credit/_id.vue
+++ b/src/ui/pages/credit/_id.vue
@@ -101,7 +101,9 @@ const info = computed(() => ({
 /** display course */
 const displayCourses = computed(() =>
   reactive(
-    courses.value.map((course) => registeredCourseToDisplay(course, tags.value))
+    courses.value
+      .map((course) => registeredCourseToDisplay(course, tags.value))
+      .sort((courseA, courseB) => (courseA.code < courseB.code ? -1 : 1))
   )
 );
 


### PR DESCRIPTION
`/credit/_id`のページにおいて授業の表示順がバラバラでしたので、`code`でソートしました。