### PR TITLE
Production の Node version をアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 AS builder
+FROM node:16 AS builder
 WORKDIR /app
 
 COPY package.json yarn.lock ./


### PR DESCRIPTION
## 背景

現在 twinte-front の開発は README にある通り Node 16 が推奨されており、手元での動作確認や Vercel の Preview Deploy も Node 16 で行われているので、Production でも揃えたい。

## 変更点

Production の Node version を 14 → 16 に上げる。
