### PR TITLE
Source Map 出力時にビルドが落ちる不具合を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "extends": "@vue/tsconfig/tsconfig.web.json",
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "vite.config.ts"
+  ],
   "exclude": ["**/*.stories.ts"],
   "compilerOptions": {
     "sourceMap": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import sentryRollupPlugin from "@sentry/rollup-plugin";
+import { sentryRollupPlugin } from "@sentry/rollup-plugin";
 import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vite";
 import ViteFonts from "vite-plugin-fonts";


### PR DESCRIPTION
## 背景

PR #628 を Merge したあとに、[Main ブランチの CD が落ちる](https://github.com/twin-te/twinte-front/actions/runs/4121599921)ようになった。

原因は Source Map 出力時に用いられる [@sentry/rollup-plugin](https://www.npmjs.com/package/@sentry/rollup-plugin) の[インターフェースが変更された](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/MIGRATION.md#upgrading-from-03x-to-04x)ためである。

この部分は `vue-tsc` による型検査の対象外であり、また Source Map の出力も含めたビルドはローカルで試していなかったため、発見が遅れた。

## 変更

https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/MIGRATION.md#upgrading-from-03x-to-04x に従い `sentryRollupPlugin` の呼び出し方法を変更した。

