### PR TITLE
授業追加時の重複チェックを実装

### DIFF
--- a/src/ui/pages/add/search.vue
+++ b/src/ui/pages/add/search.vue
@@ -495,7 +495,7 @@ const addCourses = async (warning = true) => {
         .map(({ code, name }) => `【${code}】${name}`)
         .join("\n");
     displayToast(text, { type: "danger" });
-  duplicateCourses.value = await (
+    gtm?.trackEvent({ event: "duplicated-courses-error" });
     return;
   }
 

--- a/src/ui/pages/add/search.vue
+++ b/src/ui/pages/add/search.vue
@@ -194,7 +194,7 @@
         </p>
         <div class="modal__courses">
           <div
-            v-for="duplicateCourse in duplicateCourses"
+            v-for="duplicateCourse in duplicatedScheduleCourses"
             :key="duplicateCourse.name"
             class="duplicated-course"
           >
@@ -286,6 +286,7 @@ import TextFieldSingleLine from "~/ui/components/TextFieldSingleLine.vue";
 import ToggleButton from "~/ui/components/ToggleButton.vue";
 import { useSwitch } from "~/ui/hooks/useSwitch";
 import { addCoursesByCodes } from "~/ui/store/course";
+import { displayToast } from "~/ui/store/toast";
 import { getApplicableYear } from "~/ui/store/year";
 import { asyncFilter, deleteElementInArray } from "~/utils";
 import type { Schedule } from "~/domain/schedule";
@@ -469,10 +470,36 @@ const buttonState = computed(() =>
   selectedSearchResults.length > 0 ? "default" : "disabled"
 );
 
-const duplicateCourses = ref<DisplayCourse[]>([]);
+const duplicatedScheduleCourses = ref<DisplayCourse[]>([]);
 
 const addCourses = async (warning = true) => {
+  const registeredCourse = await Usecase.getRegisteredCoursesByYear(ports)(
+    year.value
+  );
+
+  if (isResultError(registeredCourse)) throw registeredCourse;
+
+  const duplicatedCourses = selectedSearchResults
+    .filter(({ course: { code: selectedCourseCode } }) => {
+      return registeredCourse.some(
+        ({ code: registeredCourseCode }) =>
+          registeredCourseCode === selectedCourseCode
+      );
+    })
+    .map(({ course }) => course);
+
+  if (duplicatedCourses.length > 0) {
+    const text =
+      `以下のコースはすでに登録されているため追加できません。\n` +
+      duplicatedCourses
+        .map(({ code, name }) => `【${code}】${name}`)
+        .join("\n");
+    displayToast(text, { type: "danger" });
   duplicateCourses.value = await (
+    return;
+  }
+
+  duplicatedScheduleCourses.value = await (
     await asyncFilter(
       selectedSearchResults,
       async ({ schedules }) =>
@@ -480,7 +507,7 @@ const addCourses = async (warning = true) => {
     )
   ).map(({ course }) => course);
 
-  if (warning && duplicateCourses.value.length > 0) {
+  if (warning && duplicatedScheduleCourses.value.length > 0) {
     openDuplicateModal();
     return;
   }

--- a/src/ui/pages/add/search.vue
+++ b/src/ui/pages/add/search.vue
@@ -287,7 +287,7 @@ import ToggleButton from "~/ui/components/ToggleButton.vue";
 import { useSwitch } from "~/ui/hooks/useSwitch";
 import { addCoursesByCodes } from "~/ui/store/course";
 import { getApplicableYear } from "~/ui/store/year";
-import { deleteElementInArray } from "~/utils";
+import { asyncFilter, deleteElementInArray } from "~/utils";
 import type { Schedule } from "~/domain/schedule";
 import type { DisplayCourse } from "~/presentation/viewmodels/course";
 
@@ -472,12 +472,11 @@ const buttonState = computed(() =>
 const duplicateCourses = ref<DisplayCourse[]>([]);
 
 const addCourses = async (warning = true) => {
-  duplicateCourses.value = (
-    await Promise.all(
-      selectedSearchResults.filter(
-        ({ schedules }) =>
-          !Usecase.checkScheduleDuplicate(ports)(year.value, schedules)
-      )
+  duplicateCourses.value = await (
+    await asyncFilter(
+      selectedSearchResults,
+      async ({ schedules }) =>
+        !(await Usecase.checkScheduleDuplicate(ports)(year.value, schedules))
     )
   ).map(({ course }) => course);
 

--- a/src/ui/store/toast.ts
+++ b/src/ui/store/toast.ts
@@ -21,7 +21,7 @@ export const displayToast = (
   option?: { displayPeriod?: number; type?: ToastType }
 ) => {
   const id = createId();
-  const displayPeriod = option?.displayPeriod ?? 3000;
+  const displayPeriod = option?.displayPeriod ?? text.length * 240; // 250 characters per minute reading speed
   const type = option?.type ?? "danger";
 
   toasts.push({ id, text, type });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -133,3 +133,11 @@ export const hasProperty = <P extends string, T>(
 ): obj is { [key in P]: T } => {
   return hasUnknownProperty(obj, prop) && clarifyPropertyType(obj, prop, fn);
 };
+
+export const asyncFilter = async <T, S>(
+  array: T[],
+  asyncCallback: (arg: T) => Promise<S>
+) => {
+  const mask = await Promise.all(array.map(asyncCallback));
+  return array.filter((_, i) => Boolean(mask[i]));
+};


### PR DESCRIPTION
Resolves #664 

## 変更点

この PR の変更点は以下です。

1. 重複スケジュール検知のロジックがバグっていたので修正しました ( https://github.com/twin-te/twinte-front/pull/665/commits/7c9c72713589fb54ed80ace9801fd7e019bda6b5 )
`Promise` を待たずに `.filter` を適応しているなどのミスで、常に重複スケジュールがないと判断されていました。
このロジックは今回の機能追加と関連がある領域だったので、この PR で直しました。
↓が出てくるように修正した
![image](https://user-images.githubusercontent.com/45098934/229328925-54a92bed-5f10-44eb-99ab-f8df9920bc6b.png)


1. すでに登録した講義がある場合に Toast でエラーを通知するようにしました ( https://github.com/twin-te/twinte-front/pull/665/commits/45fb9e3069ca5e2b92d86021ef6216af73e3b606 )
`1.` はあくまで重複スケジュールがあったときの警告で、さらに通常講義のみに限定されます。したがって 1 とは別に同じ講義を追加しようとしたらエラー Toast を出現させる仕組みが必要です。これをこのコミットで追加しました。
また Toast の表示時間も調整しました。 
![image](https://user-images.githubusercontent.com/45098934/229328909-b18b6788-e025-4049-921a-6c06c2b7ec12.png)


1. 前述の `2.` のエラーに遭遇したユーザ数を数えるための Tracking を追加しました ( https://github.com/twin-te/twinte-front/pull/665/commits/75b20cb41a6134bae07f9a4bb3e66835328d48d8 )
Sentry を見ると同様のエラーに遭遇したユーザは多く、そもそも重複した講義を登録しようとさせない UX が必要かもしれません（登録済みの講義はチェックボックスが押せないなど）
今回は暫定的な対応で修正しますが、今後上記のような改善をする場合、どれぐらいのユーザがこのエラー Toast を見たのかを知るために、Tracking を追加しました。



