### PR TITLE
検索時にすべてのコマが検索対象のときに `timetable` パラメータが `undefined` になるように

### DIFF
--- a/src/infrastructure/api/converters/timetable.ts
+++ b/src/infrastructure/api/converters/timetable.ts
@@ -7,7 +7,7 @@ import * as ApiType from "../aspida/@types";
 
 export const timetableToApi = (
   timetable: Timetable<Module, boolean>
-): ApiType.SearchCourseTimetableQuery => {
+): ApiType.SearchCourseTimetableQuery | undefined => {
   const apiPeriods: ("0" | Period)[] = ["0", ...periods];
 
   const apiTimetable = initializeObject(
@@ -15,20 +15,26 @@ export const timetableToApi = (
     initializeObject(days, initializeObject(apiPeriods, false))
   );
 
+  let areAllTrue = true;
+
   modules.forEach((module) => {
     normalDays.forEach((day) => {
       periods.forEach((period) => {
         apiTimetable[module][day][period] =
           timetable["normal"][module][day][period];
+        areAllTrue = areAllTrue && apiTimetable[module][day][period];
       });
     });
 
     specialDays.forEach((day) => {
       apiPeriods.forEach((period) => {
         apiTimetable[module][day][period] = timetable["special"][module][day];
+        areAllTrue = areAllTrue && apiTimetable[module][day][period];
       });
     });
   });
+
+  if (areAllTrue) return undefined;
 
   return apiTimetable;
 };


### PR DESCRIPTION
## 背景

最近 Twin:te の検索パフォーマンスが落ちている。
具体的には p50 で 3.03 s, p75 で 4.23 s と非常に遅くなってしまっている。
またサーバに負荷もかかっており、サーバダウンなども懸念される。

そこで調べたところ、どうやら検索時にすべてのコマが対象の時（= `timetalbe` がすべて `true` のとき）に `timetable` が `undefined` になっていないことがわかった。

どうやら[この変更](https://github.com/twin-te/twinte-front/pull/567/files#diff-18e8bd424176958a8961854b27bc7f6bdaacfd95319d07816e6d8b99e9eb418dL90)で抜け落ちてしまったらしい。
（見逃してすみません…）

## 変更

検索時にすべてのコマが検索対象のときに `timetable` パラメータが `undefined` になるように修正した。
なお全て `true` のときに `undefined` にする、という対応は検索効率に注目したものであり、ビジネスロジックではないため、UseCase は修正しなかった

この変更によって、手元でを検索したときに検索速度が数倍になった。
※手元で「GA10101」を検索したとき、検索時間の 3 回平均が 4525 ms →  1057 ms に改善した。

## 動作確認

- 検索速度が向上したことを確認
- 空きコマ検索を指定しているときに、空きコマのみが検索されていることを確認
- 空きコマ検索を指定していないときに、空きコマ範囲ではない授業も検索されていることを確認

