### PR TITLE
時間割読み込み時にローディングするように

### DIFF
--- a/src/ui/pages/index.vue
+++ b/src/ui/pages/index.vue
@@ -295,7 +295,7 @@ await setApplicableYear();
 const year = getApplicableYear();
 
 /** course */
-watchEffect(() => setCoursesByYear(year.value));
+await setCoursesByYear(year.value);
 
 /** courseType */
 const courseType = getCourseType();


### PR DESCRIPTION
## 背景

現在は時間割読み込み時に `watchEffect` が用いられているため、時間割を読み込むまでは時間割が空のように見える。
普段ならそこまで大きな問題にならないが、負荷が大きいときは長くて十秒以上読み込みに時間がかかってしまうケースがあり、その場合は時間割が消えたとユーザに思わせてしまうことがあった。

## 変更

`watchEffect` の代わりに `await` を使い、時間割取得中は Loading が表示されるようにしました。

## 動作確認

- 時間割が読み込まれるまでローディングが表示されることを確認
- 授業を追加、年度切り替えをしたときに、正常に表示が切り替わることを確認