### PR TITLE
インポートページの改善

### DIFF
--- a/src/application/usecases/course/checkScheduleDuplicate.ts
+++ b/src/application/usecases/course/checkScheduleDuplicate.ts
@@ -1,4 +1,5 @@
 import { Ports } from "~/application/ports";
+import { RegisteredCourse } from "~/domain/course";
 import { normalDays } from "~/domain/day";
 import {
   InternalServerError,
@@ -17,14 +18,23 @@ import {
 /**
  * Return true if the schedules do not overlap comparing to the schedules of registered courses. Return false otherwise.
  */
-export const checkScheduleDuplicate = ({ courseRepository }: Ports) => async (
+export const checkScheduleDuplicate = (
+  { courseRepository }: Ports,
+  registered?: RegisteredCourse[]
+) => async (
   year: number,
   schedules: Schedule[]
 ): Promise<
   boolean | UnauthorizedError | NetworkError | InternalServerError
 > => {
-  const result = await courseRepository.getRegisteredCoursesByYear(year);
-  if (isResultError(result)) return result;
+  let result: RegisteredCourse[];
+  if (registered == null) {
+    const res = await courseRepository.getRegisteredCoursesByYear(year);
+    if (isResultError(res)) return res;
+    result = res;
+  } else {
+    result = registered;
+  }
 
   const normalSchedules: NormalSchedule[] = schedules.filter(isNormalSchedule);
   const registeredNormalSchedules: NormalSchedule[] = result

--- a/src/application/usecases/course/checkScheduleDuplicate.ts
+++ b/src/application/usecases/course/checkScheduleDuplicate.ts
@@ -18,12 +18,10 @@ import {
 /**
  * Return true if the schedules do not overlap comparing to the schedules of registered courses. Return false otherwise.
  */
-export const checkScheduleDuplicate = (
-  { courseRepository }: Ports,
-  registered?: RegisteredCourse[]
-) => async (
+export const checkScheduleDuplicate = ({ courseRepository }: Ports) => async (
   year: number,
-  schedules: Schedule[]
+  schedules: Schedule[],
+  registered?: RegisteredCourse[]
 ): Promise<
   boolean | UnauthorizedError | NetworkError | InternalServerError
 > => {

--- a/src/ui/pages/import.vue
+++ b/src/ui/pages/import.vue
@@ -133,9 +133,7 @@ const result = await Usecase.getCourses(ports)(
 );
 if (isResultError(result)) throw result;
 
-const registered = await ports.courseRepository.getRegisteredCoursesByYear(
-  year.value
-);
+const registered = await Usecase.getRegisteredCoursesByYear(ports)(year.value);
 if (isResultError(registered)) throw registered;
 
 const registeredSet = new Set(
@@ -174,9 +172,10 @@ const addCourses = async (warning = true) => {
     await Promise.all(
       selectedCourseResults.value.map(async ({ course, schedules }) => ({
         course,
-        result: await Usecase.checkScheduleDuplicate(ports, registered)(
+        result: await Usecase.checkScheduleDuplicate(ports)(
           year.value,
-          schedules
+          schedules,
+          registered
         ),
       }))
     )

--- a/src/ui/pages/import.vue
+++ b/src/ui/pages/import.vue
@@ -27,8 +27,10 @@
               :isDetailed="false"
               :isExpanded="courseResult.expanded"
               :withHr="i < courseResults.length - 1"
-              @click-checkbox="courseResult.selected = !courseResult.selected"
-              @click-card="courseResult.expanded = !courseResult.expanded"
+              @click-checkbox="
+                courseResults[i].selected = !courseResult.selected
+              "
+              @click-card="courseResults[i].expanded = !courseResult.expanded"
             />
           </div>
         </Card>
@@ -46,7 +48,7 @@
       >
     </section>
     <Modal
-      v-if="duplicateCourses"
+      v-if="duplicateCourses && duplicateCourses.length > 0"
       class="duplication-modal"
       @click="duplicateCourses = []"
     >
@@ -91,7 +93,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, shallowReactive } from "vue";
+import { computed, reactive, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { usePorts } from "~/adapter";
 import Usecase from "~/application/usecases";
@@ -108,7 +110,6 @@ import { toggleSidebar } from "~/ui/store/sidebar";
 import { addCoursesByCodes } from "../store/course";
 import { displayToast } from "../store/toast";
 import { getApplicableYear, setApplicableYear } from "../store/year";
-import type { Schedule } from "~/domain/schedule";
 import type { DisplayCourse } from "~/presentation/viewmodels/course";
 
 const ports = usePorts();
@@ -132,18 +133,20 @@ const result = await Usecase.getCourses(ports)(
 );
 if (isResultError(result)) throw result;
 
-type CourseResult = {
-  course: DisplayCourse;
-  schedules: Schedule[];
-  selected: boolean;
-  expanded: boolean;
-};
+const registered = await ports.courseRepository.getRegisteredCoursesByYear(
+  year.value
+);
+if (isResultError(registered)) throw registered;
 
-const courseResults = shallowReactive<CourseResult[]>(
+const registeredSet = new Set(
+  registered.map((course) => `${course.year}_${course.code}`)
+);
+
+const courseResults = reactive(
   result.map((course) => ({
     course: courseToDisplay(course),
     schedules: course.schedules,
-    selected: true,
+    selected: !registeredSet.has(`${course.year}_${course.code}`),
     expanded: false,
   }))
 );
@@ -171,7 +174,7 @@ const addCourses = async (warning = true) => {
     await Promise.all(
       selectedCourseResults.value.map(async ({ course, schedules }) => ({
         course,
-        result: await Usecase.checkScheduleDuplicate(ports)(
+        result: await Usecase.checkScheduleDuplicate(ports, registered)(
           year.value,
           schedules
         ),


### PR DESCRIPTION
- 各授業ごとに，重複の確認のために `registered-courses` を呼んでいたので，1 回だけ呼ぶように修正
- チェックボックスなどが機能していなかったので修正
- 重複のモーダルが閉じられない問題を修正
- すでに存在している授業（科目番号一致）はデフォルトで unchecked になるように変更
  - 同じ授業を重複扱いとせずに，差分のみ追加することができるようにしました
