### PR TITLE
空白区切りで検索ができないバグを修正

### DIFF
--- a/src/ui/pages/add/search.vue
+++ b/src/ui/pages/add/search.vue
@@ -366,8 +366,8 @@ const search = async (init = true) => {
 
   const result = await Usecase.searchCourse(ports)(
     year.value,
-    keyword.value.split("/\s/"),
-    code.value.split("/\s/"),
+    keyword.value.split(/\s/),
+    code.value.split(/\s/),
     timetable,
     onlyBlank.value,
     "Cover",


### PR DESCRIPTION
## 背景

スペース区切りで検索ができないことに @SIY1121 先輩が気がついた

調べたところ以下の箇所が間違っていることが判明した
https://github.com/twin-te/twinte-front/blob/main/src/ui/pages/add/search.vue#L369

これは以下の PR の時点で誤って移植されたようである。ただしくは https://github.com/twin-te/twinte-front/pull/567/files#diff-8bdcc69cbcde246347d14c3f1ac6b925b9cedeb7d09cf880b411f2118bb85e16L412 だった。

## 変更

差分の通り

## 動作確認

- 検索時に空白区切りの授業コードが正しく split されていることを `console.log` 経由で確認
- 検索時に空白区切りのキーワードが正しく split されていることを `console.log` 経由で確認

![image](https://user-images.githubusercontent.com/45098934/230614482-304fb699-310b-41be-bc71-a5d1035a2b7d.png)
