### PR TITLE
既に追加済の授業を登録した際のエラー表示を具体的にする

### DIFF
--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -44,8 +44,12 @@ onErrorCaptured((error) => {
   } else if (error instanceof NetworkError) {
     errorMessage.value = "ネットワークエラー。通信状況をご確認下さい。";
   } else if (error instanceof InternalServerError) {
-    errorMessage.value =
-      "申し訳ございません。サーバー内でエラーが発生しました。";
+    if (error.message.includes("指定された講義は既に登録されています")) {
+      errorMessage.value = "既に追加されている授業を追加しようとしています。";
+    } else {
+      errorMessage.value =
+        "申し訳ございません。サーバー内でエラーが発生しました。";
+    }
     return true;
   } else {
     errorMessage.value = error.message;


### PR DESCRIPTION
Issue を建てずにいきなり PR を投げているので、対応方針から異論がある場合は言っていただけると🙏

## 背景

現在の実装では追加済みの授業を追加したときのエラーは「サーバエラー」扱いになり「サーバー内でエラーが発生しました。」と表示されユーザを混乱させている。

#665 で検索画面に重複検知ロジックは実装したが、どうやら防げていないパターンがある。
Sentry を見るに少なくとも過去 24 時間で 2.2 k ユーザがこのエラー画面に遭遇している可能性がある。
また Twitter などでも Twin:te が落ちたと判断されたツイートが散見される。

そこで暫定的に、重複追加時のエラーメッセージを具体的にして、ユーザが回復行動を取れるように促したい。

## 変更

重複追加時の Error Message は以下のようになる。
`6 ALREADY_EXISTS: 指定された講義は既に登録されています`
これを検知して、カスタムエラーメッセージに置き換える。

将来的にはエラーコードなど処理したいが、取り急ぎこの実装にした。

## 動作確認

- 重複追加時にカスタムエラーメッセージが表示される

![image](https://user-images.githubusercontent.com/45098934/230912535-12ae4721-4f9f-484a-8be9-681cd917bd23.png)

