### PR TITLE
ホーム画面のリクエストを並列化して読み込み速度を改善

### DIFF
--- a/src/ui/pages/index.vue
+++ b/src/ui/pages/index.vue
@@ -245,7 +245,7 @@
 <script setup lang="ts">
 import { useHead } from "@vueuse/head";
 import dayjs from "dayjs";
-import { computed, ref, watchEffect } from "vue";
+import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import { normalDays, specialDays } from "~/domain/day";
 import { baseModules } from "~/domain/module";

--- a/src/ui/pages/index.vue
+++ b/src/ui/pages/index.vue
@@ -294,14 +294,17 @@ const router = useRouter();
 await setApplicableYear();
 const year = getApplicableYear();
 
-/** course */
-await setCoursesByYear(year.value);
+await Promise.all([
+  setCoursesByYear(year.value),
+  setEvent(),
+  setNews(),
+  setSetting(),
+]);
 
 /** courseType */
 const courseType = getCourseType();
 
 /** setting */
-await setSetting();
 const setting = getSetting();
 
 /** module */
@@ -309,7 +312,6 @@ const module = await getModule();
 const currentModule: BaseModule = await getCurrentModule();
 
 /** page header */
-await setEvent();
 const event = getEvent();
 const today = dayjs();
 const calendar: PageHeaderCalendar = {
@@ -400,7 +402,6 @@ const onClickCourseTile = async (
 };
 
 /** news modal */
-await setNews();
 const unreadNews = getUnreadNews();
 
 const [isNewsModalVisible, , closeNewsModal] = useSwitch(


### PR DESCRIPTION
## 背景

https://github.com/twin-te/twinte-front/pull/670#issuecomment-1498367697

## 変更

ホーム画面の初期リクエストを可能な範囲で並列化した

結果上下 1 Mbps の環境ではローディング時間が 6.8s → 5.7s に改善した。
上下 1 Mbps は一般に遅いが、通信環境の悪い教室などでモバイル端末で時間割を閲覧するシチューエーションを考えれば、十分ありうる値と考えている。
またサーバ側のリクエスト処理が遅いのも原因なので、通信速度が高速な環境でも並列化の恩恵を受けれると考える。

修正前: ウォーターフォールの列でリクエストが直列になっていることがわかる。
![image](https://user-images.githubusercontent.com/45098934/231057498-75fd13ce-7905-4cd7-a456-a3e6609d93bd.png)

修正後: ウォーターフォールの列で一部のリクエストが並列化されていることがわかる。
![image](https://user-images.githubusercontent.com/45098934/231057489-8f546e24-be3f-40ab-b656-d9f8ba7052f6.png)



