### PR TITLE
検索リクエストのパラメータを修正

### DIFF
--- a/src/infrastructure/api/converters/course.ts
+++ b/src/infrastructure/api/converters/course.ts
@@ -21,3 +21,11 @@ export const apiToCourse = (apiCourse: ApiType.Course): Course => {
     rooms,
   };
 };
+
+// For search performance, exclude `codes` property in the request when codes is an empty string
+export const codesForSearchRequest = (codes: string[]): string[] | undefined =>
+  codes.length === 0 || codes.at(0) === "" ? undefined : codes;
+
+// For search performance, make keywords array empty when keyword is an empty string
+export const keywordsForSearchRequest = (keywords: string[]): string[] =>
+  keywords.at(0) === "" ? [] : keywords;

--- a/src/repositories/production/CourseRepository.ts
+++ b/src/repositories/production/CourseRepository.ts
@@ -14,7 +14,11 @@ import { Tag } from "~/domain/tag";
 import { Timetable } from "~/domain/timetable";
 import { Api } from "~/infrastructure/api";
 import * as ApiType from "~/infrastructure/api/aspida/@types";
-import { apiToCourse } from "~/infrastructure/api/converters/course";
+import {
+  apiToCourse,
+  codesForSearchRequest,
+  keywordsForSearchRequest,
+} from "~/infrastructure/api/converters/course";
 import {
   apiToRegisteredCourse,
   registeredCourseToApi,
@@ -56,8 +60,8 @@ export class CourseRepository implements ICourseRepository {
     const reqBody = {
       year,
       searchMode,
-      keywords,
-      codes,
+      keywords: keywordsForSearchRequest(keywords),
+      codes: codesForSearchRequest(codes),
       timetable: timetableToApi(timetable),
       offset,
       limit,


### PR DESCRIPTION
## 背景

Resolves #685 

## 変更

Issue にある通り
上記 Issue に書いてあるプロパティ変換はどこのレイヤーで行うか迷ったのですが、`/infrastructure` の `converters` にしました。
今回のパフォーマンスを考慮した変更は外部（API Server）に依存したものなので、infrastructure に書きました。

## 動作確認

 - [x] 科目番号とキーワードを入力したときに今まで通りのリクエスト内容が飛んでいる
 - [x] 科目番号を空にしたときにリクエストの `codes` プロパテっが存在しない
    ![image](https://user-images.githubusercontent.com/45098934/235585603-9efef3ff-60fc-4882-b905-e22d584405ca.png)
 - [x] キーワードを空にしたときにリクエストの  `keyword` が `[""]` ではなく `[]` となっている
    ![image](https://user-images.githubusercontent.com/45098934/235585562-9b2453d5-0f52-496a-a698-2a5ce7bb9251.png)
