### PR TITLE
トグルスイッチが反応しないバグを修正

### DIFF
--- a/src/ui/pages/add/search.vue
+++ b/src/ui/pages/add/search.vue
@@ -50,7 +50,7 @@
             <ToggleButton
               :labels="{ left: '詳細', right: '簡易' }"
               :which-selected="detailed ? 'left' : 'right'"
-              @click-toggle-button="toggleDetailed"
+              @click-toggle-button="toggleDetailed()"
             />
           </div>
           <div class="option__accordion-toggle" @click="toggleAccordion">
@@ -75,7 +75,7 @@
             <div class="accordion__only-blank" @click="toggleOnlyBlank()">
               <Checkbox
                 :isChecked="onlyBlank"
-                @clickCheckbox.stop="toggleOnlyBlank"
+                @clickCheckbox.stop="toggleOnlyBlank()"
               ></Checkbox>
               空いているコマのみを検索
             </div>


### PR DESCRIPTION
##背景

Resolves https://github.com/twin-te/twinte-front/issues/684

https://github.com/twin-te/twinte-front/pull/628#discussion_r1094100692 のように、パッケージアップデート以降 `useToggle` の挙動が変わり、`@click="togglehoge()"` のように `()` つきで呼び出さないと今まで通りの挙動にならなくなった。

しかし https://github.com/twin-te/twinte-front/pull/628 ではいくつか `()` をつけ忘れたものがあり、それ以降、トグルボタンが反応しなくなっていた。（すみません…

## 解決策

`useToggle` で全文検索を行い、使用されている箇所を `()` 付きで呼び出すように変更した。

## 動作確認

 - 空きコマ検索のチェックボックスが正常に動作する
 - 詳細・簡易のチェックボックスが正常に動作する