### PR TITLE
Use ` --frozen-lockfile` option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16 AS builder
 WORKDIR /app
 
 COPY package.json yarn.lock ./
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 ENV VITE_API_URL=https://app.twinte.net/api/v3
 


### PR DESCRIPTION
## 背景

[`--frozen-lockfile`](https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile) オプションは以下のような挙動になります。

> Don’t generate a yarn.lock lockfile and fail if an update is needed.

開発時とデプロイ時で依存パッケージのバージョンが違うとバグの発生やその原因調査が困難になる可能性が高いです。
そのため、デプロイに使用する `Dockerfile` では `--frozen-lockfile` オプションを付けたいです。


## 変更

`--frozen-lockfile` を付与した。
