### PR TITLE
Decrease Sentry `replaysSessionSampleRate`

### DIFF
--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -23,7 +23,7 @@ Sentry.init({
     }),
   ],
   tracesSampleRate: 1.0,
-  replaysSessionSampleRate: 0.1,
+  replaysSessionSampleRate: 0.01,
   replaysOnErrorSampleRate: 1.0,
   logErrors: true,
 });


### PR DESCRIPTION
## 背景

Sentry の Replay の月 1 万回制限を使い切ってしまい、Error Log で Replay を見ることができなくなってしまっている。
原因は通常の Session の Replay が膨大で、前述の制限をすぐに消費してしまうため。

## 変更

通常の Session の Replay を取得する Sampling Rate を示す `replaysSessionSampleRate` を `0.01` まで落とす。

### `0.01` の根拠

極力すべての Error Log では Replay を取得したい。そのため Replay の消費枠の内 7000 件程度は Error log に使用し、残る 3000 件を通常の Session の Replay に割り当てたい。
月に Sentry の Session は 12 - 40 万ほどと予測されるので、その `0.01` の 1200 - 4000 であれば、おおよそ目標範囲内に収まる。

なお、Error 以外の Session Replay を記録する理由は、明示的に Error として扱われない（Error が throw されない）不具合の調査をスムーズにするため。
ex) 特定の端末でのレイアウト崩れなど

