### PR TITLE
通知設定がサイドバーに残っていたため、追加で削除

### DIFF
--- a/src/ui/templates/Sidebar.vue
+++ b/src/ui/templates/Sidebar.vue
@@ -87,12 +87,6 @@ const settings = ref<Content[]>(
       link: "/settings",
       show: true,
     },
-    {
-      iconName: "notifications",
-      item: "通知設定",
-      link: "settings",
-      show: isMobile(),
-    },
   ].filter((v) => v.show)
 );
 


### PR DESCRIPTION
モバイルで閲覧したところ通知設定がサイドバーに残っていたため、追加で削除を行った